### PR TITLE
Add a BufferedInputStream type

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -99,6 +99,8 @@ public :
       closable?: long
    deftype StringInputStream <: InputStream & Lengthable
 
+   deftype BufferedInputStream <: InputStream
+
    lostanza deftype RandomAccessFile :
       file: ptr<?>
       writable: ref<True|False>
@@ -1741,7 +1743,7 @@ public defmulti fill (xs:CharArray, r:Range, i:InputStream) -> Int
 ;                Abstract Implementations
 ;                ========================
 
-defmethod fill (xs:CharArray, r:Range, s:FileInputStream) -> Int :
+defmethod fill (xs:CharArray, r:Range, s:InputStream) -> Int :
    #if-not-defined(OPTIMIZE) :
       ensure-index-range(xs, r)
    val [b,e] = range-bound(xs, r)
@@ -1754,6 +1756,113 @@ defmethod fill (xs:CharArray, r:Range, s:FileInputStream) -> Int :
             (c:False) : i - b
       else : i - b
    loop(b)
+
+;============================================================
+;=============== Buffered Input Streams =====================
+;============================================================
+
+;                      Interface
+;                      =========
+
+public defmulti peek? (i:BufferedInputStream, n:Int) -> Char|False
+public defmulti peek-fill (xs:CharArray, r:Range, i:BufferedInputStream) -> Int
+
+;                Abstract Implementations
+;                ========================
+
+public defn peek? (i:BufferedInputStream) -> Char|False :
+   peek?(i, 0)
+
+val DEFAULT-BUFFER-SIZE = 1024
+
+public defn BufferedInputStream (i:InputStream) -> BufferedInputStream :
+   BufferedInputStream(i, DEFAULT-BUFFER-SIZE)
+
+public defn BufferedInputStream (i:InputStream, size:Int) -> BufferedInputStream :
+   if size <= 0:
+      fatal("BufferedInputStream buffer size must be greater than or equal to 0.")
+   val buffer = CharArray(size)
+   var count = 0
+   var index = 0
+
+   defn internal-fill-preserve () -> Int :
+      val preserve = count - index
+      buffer[0 to preserve] = buffer[index to count]
+      count = preserve + fill(buffer, preserve to size, i)
+      index = 0
+      count
+
+   defn internal-fill () -> Int :
+      count = fill(buffer, 0 to size, i)
+      index = 0
+      count
+
+   new BufferedInputStream:
+      defmethod get-char (this) :
+         if index >= count and internal-fill() == 0 :
+            false
+         else:
+            index = index + 1
+            buffer[index - 1]
+
+      defmethod get-byte (this) :
+         match(get-char(this)) :
+            (c:Char): to-byte(c)
+            (c:False): c
+
+      defmethod fill (xs:CharArray, r:Range, this) -> Int :
+         #if-not-defined(OPTIMIZE) :
+            ensure-index-range(xs, r)
+         val [b, e] = range-bound(xs, r)
+         val needed = e - b
+         defn fill-helper (xs:CharArray, start:Int) -> Int:
+            val still-needed = e - start
+            label<Int> return :
+               if index >= count :
+                  if still-needed > size :
+                     return(fill(xs, r, i))
+                  else if internal-fill() == 0 :
+                     return(0)
+               val available = count - index
+               val to-fill = available when available < still-needed else still-needed
+               xs[start to start + to-fill] = buffer[index to index + to-fill]
+               index = index + to-fill
+               return(to-fill)
+         defn* loop (total:Int) -> Int :
+            val n = fill-helper(xs, b + total)
+            val new-total = total + n
+            if n == 0 :
+               new-total
+            if new-total == needed :
+               needed
+            else :
+               loop(new-total)
+         loop(0)
+
+      defmethod peek-fill (xs:CharArray, r:Range, this) -> Int :
+         #if-not-defined(OPTIMIZE) :
+            ensure-index-range(xs, r)
+         val [b, e] = range-bound(xs, r)
+         val needed = e - b
+         if needed > size :
+            fatal("Cannot peek-fill %_ chars from BufferedInputStream with buffer size %_." % [needed, size])
+         if needed > count - index :
+            internal-fill-preserve()
+         if needed > count :
+            xs[b to b + count] = buffer[0 to count]
+            count
+         else :
+            xs[r] = buffer[0 to needed]
+            needed
+
+      defmethod peek? (this, n:Int) -> Char|False :
+         if n < 0 :
+            fatal("Cannot peek? into a BufferedInputStream at a negative index.")
+         if n >= size :
+            fatal("Cannot peek? %_ chars ahead into BufferedInputStream with buffer size %_." % [n, size])
+         if index + n >= count :
+            internal-fill-preserve()
+         false when index + n >= count else buffer[index + n]
 
 ;============================================================
 ;================= File Input Streams =======================

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1801,21 +1801,21 @@ public defn BufferedInputStream (i:InputStream, size:Int) -> BufferedInputStream
       defmethod get-char (this) :
          if index >= count and internal-fill() == 0 :
             false
-         else:
+         else :
             index = index + 1
             buffer[index - 1]
 
       defmethod get-byte (this) :
          match(get-char(this)) :
-            (c:Char): to-byte(c)
-            (c:False): c
+            (c:Char) : to-byte(c)
+            (c:False) : c
 
       defmethod fill (xs:CharArray, r:Range, this) -> Int :
          #if-not-defined(OPTIMIZE) :
             ensure-index-range(xs, r)
          val [b, e] = range-bound(xs, r)
          val needed = e - b
-         defn fill-helper (xs:CharArray, start:Int) -> Int:
+         defn fill-helper (xs:CharArray, start:Int) -> Int :
             val still-needed = e - start
             label<Int> return :
                if index >= count :

--- a/tests/buffered-input-stream.stanza
+++ b/tests/buffered-input-stream.stanza
@@ -5,7 +5,7 @@ defpackage buffered-input-stream :
 val test-string = "This is a test of Stanza's new BufferedInputStream."
 
 defn assert-equal (a:Equalable, b:Equalable) :
-    if a != b:
+    if a != b :
         fatal("Assertion failed. Expected %_ , but got %_" % [b, a])
 
 ; Checks that iterating through a BufferedInputStream works for different buffer sizes
@@ -51,21 +51,21 @@ defn test-peek-fill () :
                     assert-equal(xs[k], test-string[k - i])
 
 ; Cannot make a BufferedInputStream with buffer size <= 0
-defn test-buffer-size-is-positive ():
+defn test-buffer-size-is-positive () :
     BufferedInputStream(StringInputStream(test-string), 0)
 
 ; Cannot peek? backwards into a BufferedInputStream
-defn test-peek-error ():
+defn test-peek-error () :
     val stream = BufferedInputStream(StringInputStream(test-string), -1)
     peek?(stream, -1)
 
 ; Cannot peek? into a BufferedInputStream farther than its buffer size
-defn test-peek-error2 ():
+defn test-peek-error2 () :
     val stream = BufferedInputStream(StringInputStream(test-string), 5)
     peek?(stream, 10)
 
 ; Cannot peek-fill more character from a BufferedInputStream than its buffer size
-defn test-peek-fill-error ():
+defn test-peek-fill-error () :
     val stream = BufferedInputStream(StringInputStream(test-string), 5)
     peek-fill(CharArray(10), 0 to 10, stream)
 

--- a/tests/buffered-input-stream.stanza
+++ b/tests/buffered-input-stream.stanza
@@ -1,0 +1,77 @@
+defpackage buffered-input-stream :
+    import core
+    import collections
+
+val test-string = "This is a test of Stanza's new BufferedInputStream."
+
+defn assert-equal (a:Equalable, b:Equalable) :
+    if a != b:
+        fatal("Assertion failed. Expected %_ , but got %_" % [b, a])
+
+; Checks that iterating through a BufferedInputStream works for different buffer sizes
+defn test-basic () :
+    for buffer-size in 1 to 55 do :
+        val buffered-stream = BufferedInputStream(StringInputStream(test-string), buffer-size)
+        val read-chars = Vector<Char>()
+        while peek?(buffered-stream) is Char :
+            add(read-chars, get-char(buffered-stream) as Char)
+        assert-equal(string-join(read-chars), test-string)
+
+; Checks that iterating and peeking at different locations in a BufferedInputStream works for different buffer sizes
+defn test-peek? () :
+    for buffer-size in 1 to 55 do :
+        val buffered-stream = BufferedInputStream(StringInputStream(test-string), buffer-size)
+        var string-index = 0
+        while peek?(buffered-stream) is Char :
+            for i in 0 to min(buffer-size, (length(test-string) - string-index)) do :
+                assert-equal(peek?(buffered-stream, i), test-string[string-index + i])
+            get-char(buffered-stream)
+            string-index = string-index + 1
+
+; Checks that filling a BufferedInputStream works for different ranges and buffer sizes
+defn test-fill () :
+    for buffer-size in 1 to length(test-string) do :
+        for i in 1 to length(test-string) do :
+            for j in (i + 1) to length(test-string) do :
+                val buffered-stream = BufferedInputStream(StringInputStream(test-string), buffer-size)
+                val array = CharArray(length(test-string))
+                fill(array, i to j, buffered-stream)
+                for k in i to j do :
+                    assert-equal(array[k], test-string[k - i])
+
+; Checks that peek-filling a BufferedInputStream works for different ranges and buffer sizes
+defn test-peek-fill () :
+    for buffer-size in 1 to length(test-string) do :
+        val buffered-stream = BufferedInputStream(StringInputStream(test-string), buffer-size)
+        for i in 0 to buffer-size do :
+            for j in (i + 1) to buffer-size do :
+                val xs = CharArray(buffer-size)
+                peek-fill(xs, i to j, buffered-stream)
+                for k in i to j do :
+                    assert-equal(xs[k], test-string[k - i])
+
+; Cannot make a BufferedInputStream with buffer size <= 0
+defn test-buffer-size-is-positive ():
+    BufferedInputStream(StringInputStream(test-string), 0)
+
+; Cannot peek? backwards into a BufferedInputStream
+defn test-peek-error ():
+    val stream = BufferedInputStream(StringInputStream(test-string), -1)
+    peek?(stream, -1)
+
+; Cannot peek? into a BufferedInputStream farther than its buffer size
+defn test-peek-error2 ():
+    val stream = BufferedInputStream(StringInputStream(test-string), 5)
+    peek?(stream, 10)
+
+; Cannot peek-fill more character from a BufferedInputStream than its buffer size
+defn test-peek-fill-error ():
+    val stream = BufferedInputStream(StringInputStream(test-string), 5)
+    peek-fill(CharArray(10), 0 to 10, stream)
+
+test-basic()
+test-peek?()
+test-fill()
+test-peek-fill()
+
+exit(0)


### PR DESCRIPTION
This pull request adds a BufferedInputStream as discussed in #36 .

It also changes the abstract implementation of `fill` to be valid for all `InputStream` types, because it does not use any `FileInputStream`-specific functionality.

I added a simple test file in `tests/buffered-input-streams.stanza`, which test the basic functionality. If compiling and running that file results in a return code of 0, then the tests were successful.

Please let me know if you would like me to refactor any of the code, add comments, or provide exhaustive tests. Thanks!
