### PR TITLE
Added the help command to stanza.

### DIFF
--- a/compiler/stz-arg-parser.stanza
+++ b/compiler/stz-arg-parser.stanza
@@ -10,35 +10,37 @@ defpackage stz/arg-parser :
 
 public defstruct Command :
    name: String
+   args: Maybe<String>
+   description: String
    flags: Collection<Flag>
    action: ParseResult -> ?
 
-public defn MarkerFlag (name:String) :
-   Flag(name, 0, 0, true, false)
+public defn MarkerFlag (name:String, description:String) :
+   Flag(name, description, 0, 0, List(), true, false)
 
-public defn GreedyFlag (name:String, optional?:True|False) :
-   Flag(name, 1, 1, optional?, true)
-   
-public defn SingleFlag (name:String, optional?:True|False) :
-   Flag(name, 1, 1, optional?, false)
+public defn GreedyFlag (name:String, description:String, arg-name:String, optional?:True|False) :
+   Flag(name, description, 1, 1, List(arg-name), optional?, true)
 
-public defn SingleFlag (name:String) :
-   SingleFlag(name, false)
+public defn SingleFlag (name:String, description:String, arg-name:String, optional?:True|False) :
+   Flag(name, description, 1, 1, List(arg-name) optional?, false)
 
-public defn MultipleFlag (name:String, min:Int, max:Int, optional?:True|False) :
-   Flag(name, min, max, optional?, false)
+public defn SingleFlag (name:String, description:String, arg-name:String) :
+   SingleFlag(name, description, arg-name, false)
 
-public defn MultipleFlag (name:String, min:Int, optional?:True|False) :
-   Flag(name, min, INT-MAX, optional?, false)
+public defn MultipleFlag (name:String, description:String, min:Int, max:Int, arg-names:List<String>, optional?:True|False) :
+   Flag(name, description, min, max, arg-names, optional?, false)
 
-public defn MultipleFlag (name:String, min:Int) :
-   Flag(name, min, INT-MAX, false, false)
+public defn MultipleFlag (name:String, description:String, min:Int, arg-name:String, optional?:True|False) :
+   Flag(name, description, min, INT-MAX, List(arg-name), optional?, false)
 
-public defn MultipleFlag (name:String, optional?:True|False) :
-   Flag(name, 0, INT-MAX, optional?, false)
+public defn MultipleFlag (name:String, description:String, min:Int, arg-name:String) :
+   Flag(name, description, min, INT-MAX, List(arg-name), false, false)
 
-public defn MultipleFlag (name:String) :
-   Flag(name, 0, INT-MAX, false, false)
+public defn MultipleFlag (name:String, description:String, arg-name:String, optional?:True|False) :
+   Flag(name, description, 0, INT-MAX, List(arg-name) optional?, false)
+
+public defn MultipleFlag (name:String, description:String, arg-name:String) :
+   Flag(name, description, 0, INT-MAX, List(arg-name), false, false)
 
 public deftype ParseResult
 public defmulti command (r:ParseResult) -> String
@@ -49,7 +51,7 @@ public defmulti flag? (r:ParseResult, flag:String) -> String|List<String>|False|
 public defn flag?<?D> (r:ParseResult, name:String, default:?D) -> String|List<String>|D|True :
    match(flag?(r, name)) :
       (f:False) : default
-      (f:String|List<String>|True) : f   
+      (f:String|List<String>|True) : f
 
 public defn flag (r:ParseResult, name:String) -> String|List<String>|True :
    match(flag?(r, name)) :
@@ -78,8 +80,10 @@ public defn multiple?<?D> (r:ParseResult, name:String, default:?D) :
 
 public defstruct Flag :
    name: String
+   description: String
    min-arity: Int
    max-arity: Int
+   arg-names: List<String>
    optional?: True|False
    eats-next?: True|False
 

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -14,7 +14,7 @@ defpackage stz/main :
   import stz/repl
   import stz/gen-bindings
   import stz/dependencies
-  
+
   ;Macro Packages
   import stz/ast-lang
   import stz/reader-lang
@@ -23,6 +23,63 @@ defpackage stz/main :
   import stz/renamer-lang
   import stz/resolver-lang
   import stz/serializer-lang
+
+;============================================================
+;====================== Help ---=============================
+;============================================================
+
+defn print-cmd (o:OutputStream, cmd:Command, out-flags:True|False) :
+  print(o, "%_" % [name(cmd)])
+  if out-flags :
+    match(args(cmd)) :
+      (x:None) : false
+      (x:One<String>) : print(o, " %_" % [value?(x)])
+  print(o, "\n")
+
+  print(o, "%_\n" % [description(cmd)])
+  if out-flags :
+    if not empty?(to-seq(flags(cmd))) :
+      print(o, "\nFlags:\n")
+      for flag in flags(cmd) do :
+        if name(flag) != "h" and name(flag) != "-help" :
+          print(o, flag)
+          print(o, "\n")
+
+defmethod print (o:OutputStream, flag:Flag) :
+  print(o, "-%_" % [name(flag)])
+  if max-arity(flag) == INT-MAX :
+    for i in 0 to 4 do :
+      print(o, " %_%_" % [head(arg-names(flag)), i])
+    print(o, " ...")
+  else :
+    for x in arg-names(flag) do :
+      print(o, " %_" % [x])
+  print(o, "\n%_\n" % [description(flag)])
+
+defn list-all-commands () :
+  println("Usage: stanza COMMAND")
+  println("Available commands:")
+  ; Just list all of the commands
+  for cmd in STANZA-COMMANDS do :
+    print-cmd(STANDARD-OUTPUT-STREAM,cmd,false)
+
+defn help (parsed:ParseResult) :
+  if length(args(parsed)) == 0 :
+    list-all-commands()
+  else if length(args(parsed)) == 1 :
+    ; Print the help of the selected command
+    for cmd in STANZA-COMMANDS do :
+      if name(cmd) == head(args(parsed)) :
+        print-cmd(STANDARD-OUTPUT-STREAM,cmd,true)
+  else :
+    throw(Exception("Command help takes zero or one arguments."))
+
+
+public val HELP-COMMAND =
+    Command("help", One("[command_name]"),
+            append-all(["\tPrints out this help command. It optionally takes an argument of a command name.\n"
+                       ,"\tIf an argument is given, then it lists a detailed help of that command."]),
+                    [], help)
 
 ;============================================================
 ;====================== Version =============================
@@ -43,7 +100,7 @@ defn print-version () :
    println(ABOUT-MSG % [version])
 
 public val VERSION-COMMAND =
-  Command("version", [], print-version{})
+  Command("version", None(), "\tPrints out the version of this compiler.", [], print-version{})
 
 ;============================================================
 ;================== Compilation =============================
@@ -59,7 +116,7 @@ public defstruct BuildJob :
   pkg: Maybe<String>
   optimize?: True|False
   verbose?: True|False
-  
+
 defn stanza-file (path:String) :
   norm-path(path % [STANZA-INSTALL-DIR])
 
@@ -91,7 +148,7 @@ defn call-cc (asmfile:String, outfile:String, ccfiles:List<String>, ccflag-strin
     `PLATFORM-WINDOWS : "PLATFORM_WINDOWS"
     `PLATFORM-LINUX : "PLATFORM_LINUX"
     `PLATFORM-OS-X : "PLATFORM_OS_X"
-     
+
   ;Create command
   val cmd-args = [
     cc-name
@@ -100,9 +157,9 @@ defn call-cc (asmfile:String, outfile:String, ccfiles:List<String>, ccflag-strin
     stanza-file("%_/runtime/driver.c")
     ccfiles
     "-o" outfile
-    "-lm" pi-flag ccflags    
+    "-lm" pi-flag ccflags
     "-D" platform]
-  
+
   ;Call system compiler
   call-system(cc-name, flatten(cmd-args))
 
@@ -114,9 +171,9 @@ public defn compile (job:BuildJob) :
   if empty?(filenames(job)) :
     throw $ Exception("No input files given.")
   if empty?(assembly(job)) and empty?(output(job)) and empty?(pkg(job)) :
-    throw $ Exception("Stanza compile command requires either at least one of the following flags: -s, -o, or -pkg.")
+    throw $ Exception("Stanza compile command requires either at least one of the following flags: -s, -o, or -pkg. Enter 'stanza help' for more information.")
 
-  ;Flag settings   
+  ;Flag settings
   add-flag(`OPTIMIZE) when optimize?(job)
   add-flag(`VERBOSE) when verbose?(job)
 
@@ -124,10 +181,10 @@ public defn compile (job:BuildJob) :
   val pkg-dir = if empty?(pkg(job)) : "."
                 else : value!(pkg(job))
   STANZA-PKG-DIRS = cons(pkg-dir, STANZA-PKG-DIRS)
-    
+
   ;Flags
   do(add-flag, flags(job))
-  
+
   ;Platform override
   if not empty?(platform(job)) :
     val p = value!(platform(job))
@@ -163,9 +220,14 @@ public defn compile (job:BuildJob) :
 
   ;Delete assembly file
   if temporary? :
-    delete-file(asmfile as String) 
+    delete-file(asmfile as String)
 
 defn compile (parsed:ParseResult) :
+  ;User attempts to get help. Assumes that compile is the default command.
+  if has-flag?(parsed, "h") or has-flag?(parsed, "-help") :
+      list-all-commands()
+      exit(0)
+
   ;Verify input files
   if length(multiple?(parsed, "pkg", List())) > 1 :
     throw $ Exception("Multiple pkg output directories given.")
@@ -203,22 +265,31 @@ defn compile (parsed:ParseResult) :
 
 public val COMPILE-COMMAND =
   Command("compile",
-   [SingleFlag("s", true),
-    SingleFlag("o", true),
-    SingleFlag("platform", true)
-    MultipleFlag("pkg", true)
-    MultipleFlag("ccfiles", true)
-    MultipleFlag("flags", true)
-    GreedyFlag("ccflags", true)
-    MarkerFlag("optimize")
-    MarkerFlag("verbose")]
+   One("stanza_src0 [stanza_src1 stanza_src2 ...]"),
+   "\tCompile the files listed after this command. If no command is given,\n\tcompile is assumed.",
+   [SingleFlag("s", "Output assembly file of name assembly_file_name.", "assembly_file_name", true),
+    SingleFlag("o", "Output binary file of name binary_name.", "binary_name", true),
+    SingleFlag("platform", "Specify the target operating system platform.", "os-x|linux|windows", true)
+    MultipleFlag("pkg", "Specify the package output directory, out_dir", "out_dir", true)
+    MultipleFlag("ccfiles", "Specify c files to be compiled. Used for FFI.", "c_file", true)
+    MultipleFlag("flags", append-all(["Specify Stanza compiler flags. Supported flags:\n"
+                                     ,"\tPLATFORM-OS-X\n"
+                                     ,"\tPLATFORM-LINUX\n"
+                                     ,"\tPLATFORM-WINDOWS\n"
+                                     ,"\tOPTIMIZE\n\tVERBOSE"]), "flag", true)
+    GreedyFlag("ccflags", "Flags to be used with C compiler.", "c_flag", true)
+    MarkerFlag("optimize", "Turn on optimization")
+    MarkerFlag("verbose", "Verbose compiler output")
+    MarkerFlag("h", "")     ; Do not bother putting in description as it will not be displayed.
+    MarkerFlag("-help", "") ; Do not bother putting in description as it will not be displayed.
+    ]
     compile)
 
 ;============================================================
 ;==================== Extension =============================
 ;============================================================
 
-defn compile-cvm (outfile:String) :  
+defn compile-cvm (outfile:String) :
   ;Position independence flag
   val pi-flag =
     if flag-defined?(`PLATFORM-LINUX) : ["-ldl" "-fPIC"]
@@ -226,24 +297,24 @@ defn compile-cvm (outfile:String) :
 
   ;Get list of all files and flags
   val cc-name = "cc"
-     
+
   ;Create command
   val cmd-args = [
     cc-name
     "-c"
     "-std=gnu99"
-    stanza-file("%_/compiler/cvm.c")    
+    stanza-file("%_/compiler/cvm.c")
     "-o" outfile
     "-O2"
     pi-flag]
-  
+
   ;Call system compiler
   call-system(cc-name, flatten(cmd-args))
 
 defn extend (job:BuildJob) :
   ;Read the configuraton file so that STANZA_INSTALL_DIR works.
   read-config-file()
-  
+
   ;Compile the vm to a temporary file.
   val cvm-o = to-string("cvm%_.o" % [genid()])
   compile-cvm(cvm-o)
@@ -279,13 +350,19 @@ defn extend (parsed:ParseResult) :
     false) ;verbose
 
 public val EXTEND-COMMAND =
-  Command("extend", 
-   [SingleFlag("s", true),
-    SingleFlag("o", true),
-    MultipleFlag("ccfiles", true),
-    MultipleFlag("flags", true),
-    GreedyFlag("ccflags", true),
-    MarkerFlag("optimize")]
+  Command("extend",
+   One("file0 [file1 file2 ...]"),
+   "\tCompile files with the virtual machine, extending it.",
+   [SingleFlag("s", "Output assembly file of name assembly_file_name.", "assembly_file_name", true),
+    SingleFlag("o", "Output binary file of name binary_name.", "binary_name", true),
+    MultipleFlag("ccfiles", "Specify c files to be compiled. Used for FFI.", "c_file", true)
+    MultipleFlag("flags", append-all(["Specify Stanza compiler flags. Supported flags:\n"
+                                     ,"\tPLATFORM-OS-X\n"
+                                     ,"\tPLATFORM-LINUX\n"
+                                     ,"\tPLATFORM-WINDOWS\n"
+                                     ,"\tOPTIMIZE\n\tVERBOSE"]), "flag", true)
+    GreedyFlag("ccflags", "Flags to be used with C compiler.", "c_flag", true)
+    MarkerFlag("optimize", "Turn on optimization")]
     extend)
 
 ;============================================================
@@ -296,19 +373,19 @@ defn install (parsed:ParseResult) :
    ;Get Stanza platform
    val platform = to-symbol(single(parsed, "platform"))
    ensure-supported-platform(platform)
-   
+
    ;Get installation directory
    val install-dir = match(resolve-path("License.txt")) :
       (path:String) :
          val stz-suffix = norm-path("/License.txt")
          if suffix?(path, stz-suffix) :
             val n = length(stz-suffix)
-            path[0 to (length(path) - n)]               
-         else :  
+            path[0 to (length(path) - n)]
+         else :
             throw $ Exception("Could not determine Stanza installation directory.")
       (path:False) :
          throw $ Exception("Could not determine Stanza installation directory.")
-         
+
    defn open-config-file () :
       if has-flag?(parsed, "path") :
          val path = single(parsed, "path")
@@ -320,8 +397,8 @@ defn install (parsed:ParseResult) :
                if suffix?(fullpath, suffix) :
                   val n = length(suffix)
                   val dir = fullpath[0 to (length(fullpath) - n)]
-                  println("Stanza installation finished. Created %_ file." % [fullpath])                  
-                  println("Remember to add %_ to your STANZA_CONFIG environment variable." % [dir])                  
+                  println("Stanza installation finished. Created %_ file." % [fullpath])
+                  println("Remember to add %_ to your STANZA_CONFIG environment variable." % [dir])
                else :
                   throw $ Exception("Stanza installation failed. Could not create %_ file." % [filepath])
             (fullpath:False) :
@@ -333,7 +410,7 @@ defn install (parsed:ParseResult) :
                with-output-file(FileOutputStream(filepath), write-config-file)
             (home:False) :
                throw $ Exception("Could not locate user's home directory.")
-               
+
    defn write-config-file () :
       println("install-dir = %~" % [install-dir])
       println("platform = %~" % [platform])
@@ -342,9 +419,11 @@ defn install (parsed:ParseResult) :
    open-config-file()
 
 public val INSTALL-COMMAND =
-  Command("install", 
-   [SingleFlag("platform"),
-    SingleFlag("path", true)]
+  Command("install",
+   None(),
+   "\tInstalls Stanza's default configuration. Default directory is user's home directory (i.e. ~/.stanza).",
+   [SingleFlag("platform", "Specify the target operating system platform.", "os-x|linux|windows"),
+    SingleFlag("path", "Specify the target directory for the Stanza configuration flag.", "/the/target/dir", true)]
     install)
 
 ;============================================================
@@ -369,9 +448,11 @@ defn clean (parsed:ParseResult) :
     throw(Exception("Command clean does not take arguments."))
   clean()
 
-public val BUILD-COMMAND = Command("build", [], build)
-public val INIT-COMMAND = Command("init", [], init)
-public val CLEAN-COMMAND = Command("clean", [], clean)
+public val BUILD-COMMAND = Command("build", One("[target_name]"),
+                                  append-all(["\tBuilds a Stanza project. It looks for stanza.build in the\n"
+                                             ,"\tcurrent working directory. Default target name is main."]), [], build)
+public val INIT-COMMAND = Command("init", None(), "\tInitializes a Stanza project. Creates a default project file called stanza.build in the current working directory." [], init)
+public val CLEAN-COMMAND = Command("clean", None(), "\tRemoves all generated files created for the project." [], clean)
 
 ;============================================================
 ;===================== Path =================================
@@ -384,7 +465,7 @@ defn show-path (parsed:ParseResult) :
   read-config-file()
   println(STANZA-INSTALL-DIR)
 
-public val PATH-COMMAND = Command("path", [], show-path)
+public val PATH-COMMAND = Command("path", None(), "\tOutputs the path for where Stanza is installed.", [], show-path)
 
 ;============================================================
 ;======================= Repl Command =======================
@@ -402,13 +483,15 @@ defn repl-command (parsed:ParseResult) :
   for flag in multiple?(parsed, "flags", List()) do :
     add-flag(to-symbol(flag))
 
-  ;Launch REPL  
+  ;Launch REPL
   repl()
 
-public val REPL-COMMAND = 
+public val REPL-COMMAND =
   Command("repl",
-    [MultipleFlag("pkg", true)
-     MultipleFlag("flags", true)],
+    None(),
+    "\tRead-eval-print loop. Interactive shell for Stanza.",
+    [MultipleFlag("pkg", "Specify the Stanza package directories.", "pkg_dir", true)
+     MultipleFlag("flags", "Specify flags to repl.", "flag",  true)],
     repl-command)
 
 ;============================================================
@@ -432,8 +515,10 @@ defn run-command (parsed:ParseResult) :
 
 public val RUN-COMMAND =
   Command("run",
-    [MultipleFlag("pkg", true)
-     MultipleFlag("flags", true)],
+    One("stanza_src0 [stanza_src1 stanza_src2 ...]"),
+    "\tRuns the following files in Stanza's repl.",
+    [MultipleFlag("pkg", "List of directories to search for Stanza packages.", "pkg", true)
+     MultipleFlag("flags", "Flags to the repl.", "flag", true)],
     run-command)
 
 ;============================================================
@@ -447,8 +532,12 @@ defn generate-bindings-command (parsed:ParseResult) :
 
 public val GEN-BINDINGS-COMMAND =
   Command("gen-vmbindings",
-   [SingleFlag("o", false)]
-    generate-bindings-command)
+   One("file0 [file1 file2 ...]"),
+   append-all(["\tGenerate virtual machine bindings. Bindings can be generated\n",
+              ,"\tfrom both source files and .pkg files. Optimized .pkg files are\n",
+              ,"\tnot accepted."]),
+   [SingleFlag("o", "Output is directed to output_file_name", "output_file_name", false)],
+   generate-bindings-command)
 
 ;============================================================
 ;================= Dependency Analysis Command ==============
@@ -462,8 +551,10 @@ defn analyze-dependencies-command (parsed:ParseResult) :
 
 public val ANALYZE-DEPENDENCIES-COMMAND =
   Command("analyze-dependencies",
-   [SingleFlag("o", true)
-    MarkerFlag("optimize")]
+   One("file0 [file1 file2 ...]"),
+   "\tAnalyze the dependencies of the sources files, packages, and .pkg files.",
+   [SingleFlag("o", "Output is directed to output_file_name", "output_file_name", true)
+    MarkerFlag("optimize", "Turn on optimization.")]
     analyze-dependencies-command)
 
 ;============================================================
@@ -482,7 +573,8 @@ public val STANZA-COMMANDS = [
   GEN-BINDINGS-COMMAND
   ANALYZE-DEPENDENCIES-COMMAND
   RUN-COMMAND
-  EXTEND-COMMAND]
+  EXTEND-COMMAND
+  HELP-COMMAND]
 
 ;============================================================
 ;================== Main Interface ==========================
@@ -500,7 +592,7 @@ public defn stanza-main (args:Seqable<String>) :
     print-exceptions(e)
     exit(-1)
 
-public defn stanza-main () :  
+public defn stanza-main () :
   initialize-process-launcher()
   set-max-heap-size(STANZA-MAX-COMPILER-HEAP-SIZE)
   stanza-main(command-line-arguments()[1 to false])


### PR DESCRIPTION
Added the help command to stanza that lists the commands and optionally lists details of the command. Also added in support for -h and --help should a user attempt to use it.

This pull request address items 3 and 4 of Issue #48.

The descriptions and details may not be as detailed as necessary and for the extend command, not necessarily correct. I will leave it to Patrick to determine what the string literals should actually be. :)