### PR TITLE
Jb/sorted sets

### DIFF
--- a/compiler/stz-branch-table.stanza
+++ b/compiler/stz-branch-table.stanza
@@ -106,9 +106,6 @@ public defn BranchTable (ct:ClassTable) :
   val multi-formats = IntListTable<Int>()
   val method-multi-table = DynBiTable() ;Mapping from method to multis
 
-  ;Accelerated set flattening
-  val set-flattener = SetFlattener()
-
   ;==================================================
   ;============= Trie Table Invalidation ============
   ;==================================================
@@ -138,7 +135,7 @@ public defn BranchTable (ct:ClassTable) :
   ;==================================================
   defn compute-trie-table (i:Int) :
     val f* = resolve-format(formats[i])
-    compute-trie-table-entry(trie-table, ct, set-flattener, i, f*)
+    compute-trie-table-entry(trie-table, ct, i, f*)
     
   defn resolve-format (f:BranchFormat) :
     match(f:MultiFormat) : ResolvedMultiFormat(num-header-args(f), methods-of-multi(multi(f)))
@@ -239,10 +236,9 @@ public lostanza defn trie-table-data (bt:ref<BranchTable>) -> ptr<ptr<int>> :
 ;==================================================
 lostanza defn compute-trie-table-entry (trie-table:ref<PtrBuffer>,
                                         class-table:ref<ClassTable>,
-                                        sf:ref<SetFlattener>,
                                         i:ref<Int>,
                                         f:ref<BranchFormat>) -> ref<False> :
-  val p = to-trie-table(class-table, sf, f)
+  val p = to-trie-table(class-table, f)
   set(trie-table, i.value, p)
   return false
 
@@ -394,7 +390,6 @@ lostanza defn remove (b:ref<PtrBuffer>, i:ref<Int>) -> ref<True|False> :
 
 Input:
   ct:ClassTable
-  sf:SetFlattener
   t:TypeSet
 Output:
   arg:Arg
@@ -403,7 +398,6 @@ Output:
 
 Input:
   ct:ClassTable
-  sf:SetFlattener
   f:BranchFormat
 Output:
   table:Vector<Int>
@@ -419,7 +413,6 @@ Output:
 
 Input:
   ct:ref<ClassTable>
-  sf:ref<SetFlattener>
   f:ref<BranchFormat>
 Output:
   table:ptr<int>
@@ -428,16 +421,16 @@ Output:
 ;=======================================================<doc>
 
 ;Encoding a sequence of TypeSets into a dispatch branch
-defn make-branch-table (ct:ClassTable, sf:SetFlattener, branches:Seqable<Seqable<TypeSet>>) :
+defn make-branch-table (ct:ClassTable, branches:Seqable<Seqable<TypeSet>>) :
   DagBranchTable(
-    to-branches(branches, set-representation{ct, _}, sf),
+    to-branches(branches, set-representation{ct, _}),
     abstract-classes(ct))
 
 ;Convert a BranchFormat to a tuple of IBranch
-defn encode-branch-format (ct:ClassTable, sf:SetFlattener, f:BranchFormat) -> Vector<Int> :
+defn encode-branch-format (ct:ClassTable, f:BranchFormat) -> Vector<Int> :
   match(f) :
     (f:MatchFormat) :    
-      val branch-table = make-branch-table(ct,sf,branches(f))
+      val branch-table = make-branch-table(ct,branches(f))
       val dag = compute-dispatch-dag(branch-table, false)
       defn soln-id (s:Soln) :
         match(s) :
@@ -445,7 +438,7 @@ defn encode-branch-format (ct:ClassTable, sf:SetFlattener, f:BranchFormat) -> Ve
           (s:UniqueSoln) : index(s) + 1
       encode-dag(dag, 0, soln-id)
     (f:DispatchFormat) :
-      val branch-table = make-branch-table(ct,sf,branches(f))
+      val branch-table = make-branch-table(ct,branches(f))
       val dag = compute-dispatch-dag(branch-table, true)
       defn soln-id (s:Soln) :
         match(s) :
@@ -454,7 +447,7 @@ defn encode-branch-format (ct:ClassTable, sf:SetFlattener, f:BranchFormat) -> Ve
           (s:UniqueSoln) : index(s) + 2
       encode-dag(dag, 0, soln-id)
     (f:ResolvedMultiFormat) :
-      val branch-table = make-branch-table(ct,sf,seq(types,methods(f)))
+      val branch-table = make-branch-table(ct,seq(types,methods(f)))
       val dag = compute-dispatch-dag(branch-table, true)
       defn soln-id (s:Soln) :
         match(s) :
@@ -472,6 +465,6 @@ lostanza defn to-int-ptr (xs:ref<Vector<Int>>) -> ptr<int> :
   return p
 
 ;Conversion of a BranchFormat into a ptr<int>
-lostanza defn to-trie-table (ct:ref<ClassTable>, sf:ref<SetFlattener>, f:ref<BranchFormat>) -> ptr<int> :
-  val ints = encode-branch-format(ct, sf, f)
+lostanza defn to-trie-table (ct:ref<ClassTable>, f:ref<BranchFormat>) -> ptr<int> :
+  val ints = encode-branch-format(ct, f)
   return to-int-ptr(ints)

--- a/compiler/stz-conversion-utils.stanza
+++ b/compiler/stz-conversion-utils.stanza
@@ -1,18 +1,14 @@
 defpackage stz/conversion-utils :
   import core
   import collections
+  import stz/utils
   import stz/set-utils
   import stz/dispatch-dag
   import stz/el-ir
   import stz/typeset
   import stz/dyn-tree
 
-public defn set-to-arg (s:NumSet, sf:SetFlattener) -> Arg :
-  match(flatten(sf, s)) :
-    (s:AtomSet) : Nums(values(s))
-    (s:AllSet) : Top()
-
-public defn etype-to-arg (ct:DynTree, sf:SetFlattener, t:EType, include-abstract?:True|False) -> Arg :
+public defn etype-to-arg (ct:DynTree, t:EType, include-abstract?:True|False) -> Arg :
   defn to-set (t:EType) :
     match(t) :
       (t:EAnd) : IntersectSet([to-set(a(t)), to-set(b(t))])
@@ -22,17 +18,32 @@ public defn etype-to-arg (ct:DynTree, sf:SetFlattener, t:EType, include-abstract
         AtomSet $
           if include-abstract? : all-children(ct, n(t))
           else : all-leaves(ct, n(t))
-  set-to-arg(to-set(t), sf)
+  set-to-arg(to-set(t))
 
-public defn to-arg (t:TypeSet, set-representation:Int -> Tuple<Int>, sf:SetFlattener) -> Arg :
+public defn to-arg (t:TypeSet, set-representation:Int -> Tuple<Int>) -> Arg :
   defn to-set (t:TypeSet) :
     match(t) :
       (t:AndType) : IntersectSet(map(to-set, types(t)))
       (t:OrType) : UnionSet(map(to-set, types(t)))
       (t:TopType) : AllSet()
       (t:SingleType) : AtomSet(set-representation(type(t)))
-  set-to-arg(to-set(t), sf)
+  set-to-arg(to-set(t))
 
-public defn to-branches (bs:Seqable<Seqable<TypeSet>>, set-representation:Int -> Tuple<Int>, sf:SetFlattener) -> Tuple<Branch> :
+public defn to-branches (bs:Seqable<Seqable<TypeSet>>, set-representation:Int -> Tuple<Int>) -> Tuple<Branch> :
   to-tuple $ for b in bs seq :
-    Branch(to-tuple(seq(to-arg{_, set-representation, sf}, b)))
+    Branch(to-tuple(seq(to-arg{_, set-representation}, b)))
+
+public defn set-to-arg (s:NumSet) -> Arg :
+  match(remove-alls(s)) :
+    (s:AllSet) :
+      Top()
+    (s) :
+      defn loop (s:NumSet) :
+        match(s) :
+          (s:AtomSet) :
+            values(s)
+          (s:IntersectSet) :
+            intersect(seq(loop, sets(s)))
+          (s:UnionSet) :
+            union(seq(loop, sets(s)))
+      Nums(to-tuple $ loop(s))

--- a/compiler/stz-dispatch-dag.stanza
+++ b/compiler/stz-dispatch-dag.stanza
@@ -140,10 +140,12 @@ public defn case? (case:Tuple<Int>, b:Branch) :
 
 public defn union (args:Seqable<Arg>) -> Arg :
   label<Arg> return :
-    val numz = for arg in args filter :
-      match(arg:Nums) : true
-      else: return(arg)
-    Nums(to-tuple $ union(seq(values, numz as Seq<Nums>)))
+    val intz = generate<Tuple<Int>> :
+      for arg in args do :
+        match(arg) :
+          (arg:Nums) : yield(values(arg))
+          (arg:Top)  : return(arg)
+    Nums(to-tuple $ union(intz))
 
 ;============================================================
 ;======================= Soln Checker =======================
@@ -492,6 +494,7 @@ public defn all-solns (dag:Dag, case:Tuple<Arg>, include-amb?:True|False) -> Tup
   val solns = HashSet<Soln>()
 
   ;Test whether the default case is reachable
+  ;Currently too slow to use so use conversative approach below.
   defn default-reachable? (e:DagEntry, arg:Arg) :
     val entry-arg = union(seq(key, entries(e)))
     not subarg?(arg, entry-arg)
@@ -499,9 +502,15 @@ public defn all-solns (dag:Dag, case:Tuple<Arg>, include-amb?:True|False) -> Tup
   ;Algorithm
   defn* loop (e:DagEntry) :
     val arg = case[depth(e)]    
+    var all-subargs?:True|False = true
     for e in entries(e) do :
-      loop(value(e)) when overlap?(key(e), arg)
-    if default-reachable?(e, arg) :
+      if overlap?(key(e), arg) :
+        all-subargs? = all-subargs? and subarg?(arg, key(e))
+        loop(value(e))
+      else :
+        all-subargs? = false
+    ;Conservative approach for when default needed.
+    if not all-subargs? : ; default-reachable?(e, arg) : 
       loop(default(e))
 
   defn* loop (e:Int|Soln) :

--- a/compiler/stz-dispatch-dag.stanza
+++ b/compiler/stz-dispatch-dag.stanza
@@ -1,6 +1,8 @@
 defpackage stz/dispatch-dag :
   import core
   import collections
+  import stz/utils with:
+    prefix(IntListTable, ListTable) => utils-
 
 ;============================================================
 ;==================== Input Datastructure ===================
@@ -93,19 +95,24 @@ defmethod print (o:OutputStream, s:AmbSoln) :
 ;====================== Relations ===========================
 ;============================================================
 
+defn intersect (a:Arg, b:Arg) -> Arg :
+  match(a, b) :
+    (a:Top, b) : b
+    (a, b:Top) : a
+    (a:Nums, b:Nums) : Nums(to-tuple $ intersect(values(a), values(b)))
+
 public defn subarg? (x:Arg, y:Arg) :
   match(x, y):
     (x:Top, y:Top) : true
     (x:Nums, y:Top) : true
     (x:Nums, y:Nums) : if length(values(x)) <= length(values(y)) :
-                         all?(contains?{values(y), _}, values(x))
+                         subset?(values(x), values(y))
     (x, y): false
 
 public defn bottom? (x:Arg) :
   match(x:Nums) :
     empty?(values(x))
 
-val OVERLAP-SET = IntSet()
 public defn overlap? (x:Arg, y:Arg) :
   if bottom?(x) or bottom?(y) :
     false
@@ -113,11 +120,7 @@ public defn overlap? (x:Arg, y:Arg) :
     match(x, y) :
       (x:Top, y) : true
       (x, y:Top) : true
-      (x:Nums, y:Nums) :
-        add-all(OVERLAP-SET, values(x))
-        val result = any?({OVERLAP-SET[_]}, values(y))
-        clear(OVERLAP-SET)
-        result
+      (x:Nums, y:Nums) : overlap?(values(x), values(y))
 
 public defn covered? (y:Int, x:Arg) :
   match(x) :
@@ -136,14 +139,11 @@ public defn case? (case:Tuple<Int>, b:Branch) :
   all?(covered?, case, args(b))
 
 public defn union (args:Seqable<Arg>) -> Arg :
-  val result = label<Arg> return :
-    for arg in args do :
-      match(arg) :
-        (arg:Top) : return(arg)
-        (arg:Nums) : add-all(OVERLAP-SET, values(arg))
-    Nums(qsort(OVERLAP-SET))
-  clear(OVERLAP-SET)
-  result
+  label<Arg> return :
+    val numz = for arg in args filter :
+      match(arg:Nums) : true
+      else: return(arg)
+    Nums(to-tuple $ union(seq(values, numz as Seq<Nums>)))
 
 ;============================================================
 ;======================= Soln Checker =======================

--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -2259,9 +2259,6 @@ deftype MethodTable
 defmulti resolve-target (t:MethodTable, multi:Int, args:Tuple<EType>) -> Int|False
 
 defn MethodTable (epackage:EPackage) :
-  ;Caches
-  val sf = SetFlattener()
-  
   ;Driver
   defn driver () :
     val class-tree = make-class-tree()
@@ -2298,7 +2295,7 @@ defn MethodTable (epackage:EPackage) :
   defn create-dag (class-tree:DynTree, ms:Tuple<EDefmethod>) -> MethodDag :
     defn to-branch (m:EDefmethod) :
       val method-types = a1(func(m))
-      val args* = map(etype-to-arg{class-tree, sf, _, true}, method-types)
+      val args* = map(etype-to-arg{class-tree,  _, true}, method-types)
       Branch(args*)
     val branch-table = BranchTable(map(to-branch, ms), non-leaves(class-tree))
     val dag = compute-dispatch-dag(branch-table, true)
@@ -2315,7 +2312,7 @@ defn MethodTable (epackage:EPackage) :
   defn resolve-target (class-tree:DynTree, dag-table:IntTable<MethodDag>, multi:Int, types:Tuple<EType>) -> Int|False :
     val mdag = get?(dag-table, multi)
     match(mdag:MethodDag) :
-      val args = map(etype-to-arg{class-tree, sf, _, false}, types)
+      val args = map(etype-to-arg{class-tree, _, false}, types)
       val solns = all-solns(dag(mdag), args, false)
       if length(solns) == 1 :
         val i = index(solns[0] as UniqueSoln)

--- a/compiler/stz-set-utils.stanza
+++ b/compiler/stz-set-utils.stanza
@@ -28,68 +28,16 @@ public defstruct AllSet <: NumSet
 with:
   printer => true
 
-;============================================================
-;======================== Algorithm =========================
-;============================================================
-
-public deftype SetFlattener
-public defmulti flatten (s:SetFlattener, s:NumSet) -> AtomSet|AllSet
-
-public defn SetFlattener () :
-  val accum = MultilevelStack<KeyValue<Int,Int>>()
-  val counts = IntTable<Int>(0)
-
-  defn cache-counts (f:() -> ?) :
-    push-level(accum)
-    for entry in counts do :
-      add(accum, entry)
-    clear(counts)
-    f()
-    within e = pop-level(accum) :
-      update(counts, {_ + value(e)}, key(e))        
-
-  defn remove-alls (s:NumSet) :
-    match(s) :
-      (s:IntersectSet) :
-        var sets*:Seq<NumSet> = seq(remove-alls, sets(s))
-        sets* = filter({_ is-not AllSet}, sets*)
-        if empty?(sets*) : AtomSet([])
-        else : IntersectSet(to-tuple(sets*))        
-      (s:UnionSet) :
-        val sets* = map(remove-alls, sets(s))
-        if any?({_ is AllSet}, sets*) : AllSet()
-        else : UnionSet(sets*)
-      (s:AtomSet|AllSet) :
-        s
-    
-  defn add-to-counts (s:NumSet) :
-    match(s) :
-      (s:IntersectSet) :
-        within cache-counts() :
-          do(add-to-counts, sets(s))
-          val n = length(sets(s))
-          for entry in counts map! :
-            1 when value(entry) == n else 0            
-      (s:UnionSet) :
-        within cache-counts() :
-          do(add-to-counts, sets(s))
-          for entry in counts map! :
-            1 when value(entry) > 0 else 0
-      (s:AtomSet) :
-        for v in values(s) do :
-          update(counts, {_ + 1}, v)
-
-  new SetFlattener :
-    defmethod flatten (this, s:NumSet) :
-      match(remove-alls(s)) :
-        (s:AtomSet|AllSet) :
-          s
-        (s) :
-          add-to-counts(s)
-          val xs = to-tuple $ for e in counts seq? :
-            One(key(e)) when value(e) > 0 else None()
-          clear(counts)
-          AtomSet(xs)
-
-public defn flatten (s:NumSet) :
-  flatten(SetFlattener(), s)
+public defn remove-alls (s:NumSet) :
+  match(s) :
+    (s:IntersectSet) :
+      var sets*:Seq<NumSet> = seq(remove-alls, sets(s))
+      sets* = filter({_ is-not AllSet}, sets*)
+      if empty?(sets*) : AtomSet([])
+      else : IntersectSet(to-tuple(sets*))        
+    (s:UnionSet) :
+      val sets* = map(remove-alls, sets(s))
+      if any?({_ is AllSet}, sets*) : AllSet()
+      else : UnionSet(sets*)
+    (s:AtomSet|AllSet) :
+      s

--- a/compiler/stz-stitcher.stanza
+++ b/compiler/stz-stitcher.stanza
@@ -181,9 +181,6 @@ public defn Stitcher (packages:Collection<VMPackage>, bindings:Bindings|False, s
   val id-indices = HashTable<RecId,Int>()
   val package-ids = HashTable<Symbol,PackageIds>()
 
-  ;Acceleration
-  val sf = SetFlattener()
-
   ;Add a new global record
   defn add-global-record (r:Rec) -> Int :
     val global-id = length(global-props)
@@ -440,7 +437,7 @@ public defn Stitcher (packages:Collection<VMPackage>, bindings:Bindings|False, s
 
     ;Convert branches into branch table
     defn to-dag (ts:Seqable<Seqable<TypeSet>>, topological?:True|False) :
-      val bs = to-branches(ts, all-children{class-tree, _}, sf)
+      val bs = to-branches(ts, all-children{class-tree, _})
       val btable = BranchTable(bs, non-leaves(class-tree))
       compute-dispatch-dag(btable, topological?)
 
@@ -707,7 +704,7 @@ public defn Stitcher (packages:Collection<VMPackage>, bindings:Bindings|False, s
             match(op(i)) :
               (op:TypeofOp) :
                 val tag* = resolve(pkgids, tag(op))
-                val arg = to-arg(tag*, all-children{class-tree, _}, sf)
+                val arg = to-arg(tag*, all-children{class-tree, _})
                 emit-typeof(x(i), y(i), arg)
               (op) : E(i)
           (i) : E(i)    

--- a/compiler/stz-utils.stanza
+++ b/compiler/stz-utils.stanza
@@ -7,6 +7,81 @@ defpackage stz/utils :
    import core/sha256
 
 ;============================================================
+;====================== SORTED-SETS =========================
+;============================================================
+
+public defn assert-sorted (t:Tuple<Int>) :
+  let loop (i:Int = 1) :
+    if i < length(t) :
+      if t[i - 1] > t[i] :
+        fatal("UNSORTED %_" % [t])
+      loop(i + 1)
+
+public defn overlap? (a:Tuple<Int>, b:Tuple<Int>) -> True|False :
+  val [na, nb] = [length(a), length(b)]
+  let loop (i:Int = 0, j:Int = 0) :
+    if i < na and j < nb :
+      val [ai, bj] = [a[i], b[j]]
+      if ai < bj :
+        loop(i + 1, j)
+      else if bj < ai :
+        loop(i, j + 1)
+      else :
+        true
+    else :
+      false
+
+public defn subset? (a:Tuple<Int>, b:Tuple<Int>) -> True|False :
+  val [na, nb] = [length(a), length(b)]
+  let loop (i:Int = 0, j:Int = 0) :
+    if i < na and j < nb :
+      val [ai, bj] = [a[i], b[j]]
+      if ai < bj :
+        false
+      else if bj < ai :
+        loop(i, j + 1)
+      else :
+        loop(i + 1, j + 1)
+    else :
+      i >= na
+
+public defn union (a:Seqable<Int>, b:Seqable<Int>) -> Seq<Int> :
+  generate<Int> :
+    val [sa, sb] = [to-seq(a), to-seq(b)]
+    while not empty?(sa) and not empty?(sb) :
+      val [ai, bj] = [peek(sa), peek(sb)]
+      if ai < bj :
+        yield(next(sa))
+      else if bj < ai :
+        yield(next(sb))
+      else :
+        yield(next(sa))
+        next(sb)
+    while not empty?(sa) :
+      yield(next(sa))
+    while not empty?(sb) :
+      yield(next(sb))
+
+public defn intersect (a:Seqable<Int>, b:Seqable<Int>) -> Seq<Int> :
+  generate<Int> :
+    val [sa, sb] = [to-seq(a), to-seq(b)]
+    while not empty?(sa) and not empty?(sb) :
+      val [ai, bj] = [peek(sa), peek(sb)]
+      if ai < bj :
+        next(sa)
+      else if bj < ai :
+        next(sb)
+      else :
+        yield(next(sa))
+        next(sb)
+
+public defn union (elts:Seqable<Seqable<Int>>) -> Seqable<Int> :
+  reduce(union, elts)
+
+public defn intersect (elts:Seqable<Seqable<Int>>) -> Seqable<Int> :
+  reduce(intersect, elts)
+
+;============================================================
 ;======================= FileStamp ==========================
 ;============================================================
 

--- a/compiler/stz-vm-encoder.stanza
+++ b/compiler/stz-vm-encoder.stanza
@@ -252,9 +252,6 @@ public defn encode (func:VMFunction,
     val used-labels = to-intset(seq(n, filter-by<LabelIns>(ins(func))))
     val label-counter = to-seq(0 to false)
 
-    ;Acceleration
-    val sf = SetFlattener()
-
     ;==================================================
     ;============== Overall Algorithm =================
     ;==================================================
@@ -288,7 +285,7 @@ public defn encode (func:VMFunction,
     ;Encode a match statement that cannot be redefined later.
     defn emit-final-match (ys:Tuple<VMImm>, bs:Tuple<VMBranch>, default-label:Int) :      
       defn compute-dag () :
-        val branch-table = BranchTable(to-branches(seq(types,bs), {[_]}, sf))
+        val branch-table = BranchTable(to-branches(seq(types,bs), {[_]}))
         compute-dispatch-dag(branch-table, false)
         
       defn emit-dag (dag:Dag) :


### PR DESCRIPTION
Use sorted ints as representation of Nums so that all set operations will be O(n) instead of O(n^2).  speeds up compiler by 18%.