### PR TITLE
add waiting option to retrieve-process-state to reduce call-system ov…

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -7389,9 +7389,9 @@ defn SystemCallException (msg:String) :
   lostanza deftype StateStruct :
     state: int
     code: int
-  public lostanza defn state (p:ref<Process>, wait?:ref<True|False>) -> ref<ProcessState> :
+  public lostanza defn state (p:ref<Process>, hang?:ref<True|False>) -> ref<ProcessState> :
     val s = new StateStruct{0, 0}
-    call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait? == true) as byte)
+    call-c clib/retrieve_process_state(p.pid, addr!([s]), (hang? == true) as byte)
 
     ;State Codes
     val RUNNING = 0

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -55,7 +55,7 @@ protected extern file_time_modified: ptr<byte> -> long
 
 ;Process libraries
 protected extern launch_process: (ptr<byte>, ptr<ptr<byte>>, int, int, int, ptr<?>) -> int
-protected extern retrieve_process_state: (long, ptr<?>) -> int
+protected extern retrieve_process_state: (long, ptr<?>, byte) -> int
 protected extern initialize_launcher_process: () -> int
 
 ;Math libraries
@@ -7389,9 +7389,9 @@ defn SystemCallException (msg:String) :
   lostanza deftype StateStruct :
     state: int
     code: int
-  public lostanza defn state (p:ref<Process>) -> ref<ProcessState> :
+  public lostanza defn state (p:ref<Process>, wait?:ref<True|False>) -> ref<ProcessState> :
     val s = new StateStruct{0, 0}
-    call-c clib/retrieve_process_state(p.pid, addr!([s]))
+    call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait? == true) as byte)
 
     ;State Codes
     val RUNNING = 0
@@ -7416,7 +7416,7 @@ defn SystemCallException (msg:String) :
   public defn call-system (file:String, args:Seqable<String>) -> Int :
     val p = Process(file, args)
     let loop () :
-      match(state(p)) :
+      match(state(p, true)) :
         (s:ProcessRunning) : loop()
         (s:ProcessDone) : value(s)
         (s) : throw(ProcessAbortedError(s))

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -697,8 +697,8 @@ void get_process_state (long pid, ProcessState* s, int is_wait){
 //------------------------------------------------------------
 
 #define LAUNCH_COMMAND 0
-#define STATE_COMMAND 1
-#define STATE_WAIT_COMMAND 2
+#define STATE_NO_HANG_COMMAND 1
+#define STATE_HANG_COMMAND 2
 
 void write_error_and_exit (int fd){
   int code = errno;
@@ -782,12 +782,12 @@ void launcher_main (FILE* lin, FILE* lout){
       }
     }
     //Interpret state retrieval command
-    else if(comm == STATE_COMMAND || comm == STATE_WAIT_COMMAND){
+    else if(comm == STATE_NO_HANG_COMMAND || comm == STATE_HANG_COMMAND){
       //Read in process id
       long pid = read_long(lin);
 
       //Retrieve state
-      ProcessState s; get_process_state(pid, &s, comm == STATE_WAIT_COMMAND);
+      ProcessState s; get_process_state(pid, &s, comm == STATE_HANG_COMMAND);
       write_process_state(lout, &s);
       fflush(lout);
     }
@@ -915,7 +915,7 @@ int launch_process (char* file, char** argvs,
   return 0;
 }
 
-void retrieve_process_state (long pid, ProcessState* s, char is_wait){
+void retrieve_process_state (long pid, ProcessState* s, char is_hang){
   //Check whether launcher has been initialized
   if(launcher_pid < 0){
     fprintf(stderr, "Launcher not initialized.\n");
@@ -923,7 +923,7 @@ void retrieve_process_state (long pid, ProcessState* s, char is_wait){
   }
     
   //Send command
-  int r = fputc(is_wait ? STATE_WAIT_COMMAND : STATE_COMMAND, launcher_in);
+  int r = fputc(is_hang ? STATE_HANG_COMMAND : STATE_NO_HANG_COMMAND, launcher_in);
   if(r == EOF) exit_with_error();
   write_long(launcher_in, pid);
   fflush(launcher_in);


### PR DESCRIPTION
When using call-system use a blocking wait to stop until child process dies so as to reduce cpu overhead.