### PR TITLE
more directly encode set/table seq iteration to speed up

### DIFF
--- a/core/collections.stanza
+++ b/core/collections.stanza
@@ -712,11 +712,13 @@ public defn HashTable<K,V> (cap0:Int
   ;=============================
   defn sequence<?T> (f:TableItem<K,V> -> ?T) :
     val sizes = sizes
-    for (s in slots, idx in 0 to false) seq-cat :
-      match(s) :
-        (s:Sentinel) : List()
-        (s:TableItem<K,V>) : List(f(s))
-        (s:Array<TableItem<K,V>>) : seq(f, take-n(sizes[idx], s))
+    val slots = slots
+    generate<T> :
+      for idx in 0 to length(slots) do :
+        match(slots[idx]) :
+          (s:Sentinel) : false
+          (s:TableItem<K,V>) : yield(f(s))
+          (s:Array<TableItem<K,V>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
 
   ;======================
   ;==== Table Object ====
@@ -1112,11 +1114,13 @@ public defn IntTable<V> (cap0:Int
   ;=============================
   defn sequence<?T> (f:IntItem<V> -> ?T) :
     val sizes = sizes
-    for (s in slots, idx in 0 to false) seq-cat :
-      match(s) :
-        (s:Sentinel) : List()
-        (s:IntItem<V>) : List(f(s))
-        (s:Array<IntItem<V>>) : seq(f, take-n(sizes[idx], s))
+    val slots = slots
+    generate<T> :
+      for idx in 0 to length(slots) do :
+        match(slots[idx]) :
+          (s:Sentinel) : false
+          (s:IntItem<V>) : yield(f(s))
+          (s:Array<IntItem<V>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
 
   ;======================
   ;==== Table Object ====
@@ -1402,11 +1406,13 @@ public defn HashSet<K> (cap0:Int
   ;=============================
   defn sequence<?T> (f:SetItem<K> -> ?T) :
     val sizes = sizes
-    for (s in slots, idx in 0 to false) seq-cat :
-      match(s) :
-        (s:Sentinel) : List()
-        (s:SetItem<K>) : List(f(s))
-        (s:Array<SetItem<K>>) : seq(f, take-n(sizes[idx], s))
+    val slots = slots
+    generate<T> :
+      for idx in 0 to length(slots) do :
+        match(slots[idx]) :
+          (s:Sentinel) : false
+          (s:SetItem<K>) : yield(f(s))
+          (s:Array<SetItem<K>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
 
   ;======================
   ;==== Table Object ====
@@ -1630,11 +1636,13 @@ public defn IntSet (cap0:Int) :
   ;=============================
   defn sequence () :
     val sizes = sizes
-    for (s in slots, idx in 0 to false) seq-cat :
-      match(s) :
-        (s:Sentinel) : List()
-        (s:Int) : List(s)
-        (s:Array<Int>) : take-n(sizes[idx], s)
+    val slots = slots
+    generate<Int> :
+      for idx in 0 to length(slots) do :
+        match(slots[idx]) :
+          (s:Sentinel) : false
+          (s:Int) : yield(s)
+          (s:Array<Int>) : for j in 0 to sizes[idx] do : yield(s[j])
 
   ;======================
   ;==== Table Object ====


### PR DESCRIPTION
Write set/table seq iteration in terms of a generate loop.  By itself, makes compiler run 10% faster!