### PR TITLE
speed up dispatch-dag default to use conservative check for speed

### DIFF
--- a/compiler/stz-dispatch-dag.stanza
+++ b/compiler/stz-dispatch-dag.stanza
@@ -486,9 +486,12 @@ public defn all-solns (dag:Dag, case:Tuple<Arg>, include-amb?:True|False) -> Tup
   ;Algorithm
   defn* loop (e:DagEntry) :
     val arg = case[depth(e)]    
+    var all-subargs?:True|False = true
     for e in entries(e) do :
+      all-subargs? = all-subargs? and subarg?(arg, key(e))
       loop(value(e)) when overlap?(key(e), arg)
-    if default-reachable?(e, arg) :
+    ;Conservative approach for when default needed -- because precise one is really slow.
+    if not all-subargs? : ; default-reachable?(e, arg) :
       loop(default(e))
 
   defn* loop (e:Int|Soln) :


### PR DESCRIPTION
revert back to conservative dispatch-dag default method to improve speed of compiler.