### PR TITLE
new rev of autodoc

### DIFF
--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -385,7 +385,21 @@ defn parse-items (string:String, tag:String) -> Vector<ParsedItem> :
 
 val script-counter = to-seq(0 to false)
 
-;print definition into package file, printing anchors, and recording descriptions for later
+defn gen-fig (item:ParsedForm, pkg:IPackage, figs-dir:String, run-fig-generation?:True|False) -> String :
+  val id = next(script-counter)
+  val script-name = to-string("script%_.stanza" % [id])
+  val forms = unwrap-all(form(item))
+  val app    = forms[0]
+  val suffix = forms[1]
+  val code   = tailn(forms, 2)
+  val filename = to-string("%_/fig-%_.%_" % [name(pkg), id, suffix])
+  if run-fig-generation? :
+    val pathname = to-string("%_/%_" % [figs-dir, filename])
+    val output = to-string("call-system(\"%_\", [\"%_\", \"%_\", \"%_\", \\<s>%_<s>])" % [app, app, pathname, suffix, code])
+    spit(script-name, output)
+    call-system("stanza", ["stanza", "run", script-name])
+  to-string("figs/%_" % [filename])
+
 defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable<String>, pkg:IPackage,
                        figs-dir:String, run-fig-generation?:True|False) :
   match(e) :
@@ -421,19 +435,7 @@ defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable
           (item:ParsedText) :
             print(o, string(item))
           (item:ParsedForm) :
-            val id = next(script-counter)
-            val script-name = to-string("script%_.stanza" % [id])
-            val forms = unwrap-all(form(item))
-            val app    = forms[0]
-            val suffix = forms[1]
-            val code   = tailn(forms, 2)
-            val filename = to-string("%_/fig-%_.%_" % [name(pkg), id, suffix])
-            if run-fig-generation? :
-              val pathname = to-string("%_/%_" % [figs-dir, filename])
-              val output = to-string("call-system(\"%_\", [\"%_\", \"%_\", \"%_\", \\<s>%_<s>])" % [app, app, pathname, suffix, code])
-              spit(script-name, output)
-              call-system("stanza", ["stanza", "run", script-name])
-            val url = to-string("figs/%_" % [filename])
+            val url = gen-fig(item, pkg, figs-dir, run-fig-generation?)
             print(o, "\"%_\"" % [url])
     (e) :
       false

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -97,27 +97,40 @@ TODO:
      this will need to be revisited so that text can be updated without rerunning all the generation programs.
 ;============================================================================== <DOC>
 
+public defstruct AutoDocPluginOutputException <: Exception :
+  name: String
+
+defmethod print (o:OutputStream, e:AutoDocPluginOutputException) :
+  print(o, "Unable to read tokens from plugin %_" % [name(e)])
+
 defn call-plugin (name:String, arguments:Seqable<String>) -> String :
   val proc = Process(name, cat([name], arguments), PROCESS-IN, PROCESS-OUT, PROCESS-ERR)
   val tokens = read-line(output-stream(proc))
   val response =
     match(tokens:List<Token>) :
       if empty?(tokens) :
-        fatal("Unable to read tokens from plugin %_" % [name])
+        throw(AutoDocPluginOutputException(name))
       else :
         unwrap-token(head(tokens))
     else :
-      fatal("Unable to read tokens from plugin %_" % [name])
+      throw(AutoDocPluginOutputException(name))
   wait(proc)
   response
 
 defn call-string-plugin (name:String, args:Seqable<String>) -> String :
   call-plugin(name, args)
 
+public defstruct AutoDocPluginBooleanException <: Exception :
+  name: String
+  response: String
+
+defmethod print (o:OutputStream, e:AutoDocPluginBooleanException) :
+  print("Read invalid response %_ from boolean plugin %_" % [response(e), name(e)])
+
 defn call-boolean-plugin (name:String, args:Seqable<String>) -> True|False :
   val response = call-string-plugin(name, args)
   if not contains?(response, ["true", "false"]) :
-    fatal("Read invalid response %_ from boolean plugin %_" % [response, name])
+    throw(AutoDocPluginBooleanException(name, response))
   response == "true"
 
 defn call-string-plugin (app-name:False|String, pkg:IPackage, default:IPackage -> String, trace?:True|False) -> String :

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -97,6 +97,7 @@ TODO:
      this will need to be revisited so that text can be updated without rerunning all the generation programs.
  o add timeout check for plugin execution
  o add support for special characters in package pathnames
+ o add proper delete directory command that handles windows and escaping etc
 ;============================================================================== <DOC>
 
 public defstruct AutoDocPluginOutputException <: Exception :
@@ -487,14 +488,24 @@ defn gen-index (so:FileOutputStream, dir:String, kind:String, elts:IntTable<DefR
     println(ts, "[`%_`](%_)\n" % [description(ref), url])
   close(ts)
 
+; defn call-shell (args:Seqable<String>) :
+;   val earg = escape-shell-command $ [string-join $ args]
+;   println("EARG %_" % [earg])
+;   call-system("sh", ["sh", "-c", earg])
+
+defn call-shell (args:Seqable<String>) :
+  val earg = string-join $ args
+  ; println("EARG %_" % [earg])
+  call-system("sh", ["sh", "-c", earg])
+
 ;copy existing figs for given master-figs-dir and package to mdbook destination dir
 defn copy-figs (master-figs-dir:String, package-name:Symbol, info:False|FileInfo) :
   match(info:FileInfo) :
     val figs-dir = string-join $ [split-filepath(filename(info))[0], "figs/" package-name]
     if file-exists?(figs-dir) :
       val dst-figs-dir = string-join $ [master-figs-dir "/" package-name]
-      call-system("sh", ["sh", "-c", string-join $ ["mkdir -p " dst-figs-dir]])
-      call-system("sh", ["sh", "-c", string-join $ ["cp " figs-dir "/* " dst-figs-dir]])
+      call-shell $ ["mkdir -p " dst-figs-dir]
+      call-shell $ ["cp " figs-dir "/* " dst-figs-dir]
 
 ;print table of contents using string trees
 defn print-toc (so:OutputStream, start-depth:Int, trees:Tuple<StringTree>, packages:Vector<IPackage>) :
@@ -527,7 +538,7 @@ defn unzip<?S,?T> (elts:Seqable<KeyValue<?S,?T>>) -> [Vector<S>, Vector<T>] :
 public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPackage>, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
   val all-ipackages = to-tuple $ i-all-ipackages
   val dir = string-join $ [md-docs-dir "/src"]
-  call-system("sh", ["sh", "-c", string-join $ ["mkdir -p " dir]])
+  call-shell $ ["mkdir -p " dir]
   create-dir(dir) when not file-exists?(dir)
   val pkg-dir = string-join $ [dir "/packages"]
   val so = FileOutputStream $ string-join $ [dir "/SUMMARY.md"]

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -95,6 +95,8 @@ TODO:
  o parse-iterms is fine for now. Has some bad performance characteristics that we can revisit later.
  o the FIG processing currently runs as part of running stanza doc,
      this will need to be revisited so that text can be updated without rerunning all the generation programs.
+ o add timeout check for plugin execution
+ o add support for special characters in package pathnames
 ;============================================================================== <DOC>
 
 public defstruct AutoDocPluginOutputException <: Exception :
@@ -102,6 +104,13 @@ public defstruct AutoDocPluginOutputException <: Exception :
 
 defmethod print (o:OutputStream, e:AutoDocPluginOutputException) :
   print(o, "Unable to read tokens from plugin %_" % [name(e)])
+
+public defstruct AutoDocPluginCompletionException <: Exception :
+  name: String
+  state: ProcessState
+
+defmethod print (o:OutputStream, e:AutoDocPluginCompletionException) :
+  print(o, "Plugin failed to complete left in state %_" % [name(e), state(e)])
 
 defn call-plugin (name:String, arguments:Seqable<String>) -> String :
   val proc = Process(name, cat([name], arguments), PROCESS-IN, PROCESS-OUT, PROCESS-ERR)
@@ -114,7 +123,11 @@ defn call-plugin (name:String, arguments:Seqable<String>) -> String :
         unwrap-token(head(tokens))
     else :
       throw(AutoDocPluginOutputException(name))
-  wait(proc)
+  val state = wait(proc)
+  match(state:ProcessDone) :
+    throw(AutoDocPluginCompletionException(name, state)) when value(state) != 0
+  else :
+    throw(AutoDocPluginCompletionException(name, state))
   response
 
 defn call-string-plugin (name:String, args:Seqable<String>) -> String :
@@ -161,7 +174,7 @@ defstruct StringTree :
 defmethod print (o:OutputStream, node:StringTree) :
   print(o, "StringTree(%_, %_)" % [key(node), children(node)])
 
-;Turns list of pathname strings into a tree of strings split at slashes
+;Turns list of package strings into a tree of strings split at slashes
 ;  assumes input strings are sorted and trees maintain sorting
 defn organize-strings (strings:Seqable<String>) -> Tuple<StringTree> :
   val split-strings = to-list $ for s in strings seq : to-list $ split(s, "/")

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -97,22 +97,27 @@ TODO:
      this will need to be revisited so that text can be updated without rerunning all the generation programs.
 ;============================================================================== <DOC>
 
-defn call-plugin (name:String, arguments:Seqable<String>) -> False|String :
+defn call-plugin (name:String, arguments:Seqable<String>) -> String :
   val proc = Process(name, cat([name], arguments), PROCESS-IN, PROCESS-OUT, PROCESS-ERR)
-  ; println("WRITING HELLO")
-  ; println(input-stream(proc), "\"HELLO\"")
-  ; flush(input-stream(proc))
   val tokens = read-line(output-stream(proc))
-  val response = match(tokens:List<Token>) :
-    unwrap-token(head(tokens)) when not empty?(tokens)
+  val response =
+    match(tokens:List<Token>) :
+      if empty?(tokens) :
+        fatal("Unable to read tokens from plugin %_" % [name])
+      else :
+        unwrap-token(head(tokens))
+    else :
+      fatal("Unable to read tokens from plugin %_" % [name])
   wait(proc)
   response
 
 defn call-string-plugin (name:String, args:Seqable<String>) -> String :
-  to-string(call-plugin(name, args))
+  call-plugin(name, args)
 
 defn call-boolean-plugin (name:String, args:Seqable<String>) -> True|False :
   val response = call-string-plugin(name, args)
+  if not contains?(response, ["true", "false"]) :
+    fatal("Read invalid response %_ from boolean plugin %_" % [response, name])
   response == "true"
 
 defn call-string-plugin (app-name:False|String, pkg:IPackage, default:IPackage -> String, trace?:True|False) -> String :

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -488,14 +488,8 @@ defn gen-index (so:FileOutputStream, dir:String, kind:String, elts:IntTable<DefR
     println(ts, "[`%_`](%_)\n" % [description(ref), url])
   close(ts)
 
-; defn call-shell (args:Seqable<String>) :
-;   val earg = escape-shell-command $ [string-join $ args]
-;   println("EARG %_" % [earg])
-;   call-system("sh", ["sh", "-c", earg])
-
 defn call-shell (args:Seqable<String>) :
-  val earg = string-join $ args
-  ; println("EARG %_" % [earg])
+  val earg = escape-shell-command $ args
   call-system("sh", ["sh", "-c", earg])
 
 ;copy existing figs for given master-figs-dir and package to mdbook destination dir
@@ -504,8 +498,9 @@ defn copy-figs (master-figs-dir:String, package-name:Symbol, info:False|FileInfo
     val figs-dir = string-join $ [split-filepath(filename(info))[0], "figs/" package-name]
     if file-exists?(figs-dir) :
       val dst-figs-dir = string-join $ [master-figs-dir "/" package-name]
-      call-shell $ ["mkdir -p " dst-figs-dir]
-      call-shell $ ["cp " figs-dir "/* " dst-figs-dir]
+      call-shell $ ["mkdir" "-p" dst-figs-dir]
+      for file in dir-files(figs-dir, false) do :
+        copy-file(string-join $ [figs-dir "/" file], string-join $ [dst-figs-dir, "/" file])
 
 ;print table of contents using string trees
 defn print-toc (so:OutputStream, start-depth:Int, trees:Tuple<StringTree>, packages:Vector<IPackage>) :
@@ -538,7 +533,7 @@ defn unzip<?S,?T> (elts:Seqable<KeyValue<?S,?T>>) -> [Vector<S>, Vector<T>] :
 public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPackage>, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
   val all-ipackages = to-tuple $ i-all-ipackages
   val dir = string-join $ [md-docs-dir "/src"]
-  call-shell $ ["mkdir -p " dir]
+  call-shell $ ["mkdir" "-p" dir]
   create-dir(dir) when not file-exists?(dir)
   val pkg-dir = string-join $ [dir "/packages"]
   val so = FileOutputStream $ string-join $ [dir "/SUMMARY.md"]

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -27,7 +27,35 @@ where
 * fig-filter determines which packages produce figures -- default is `true`
 * toc-renamer script is expected to print to stdout a name to be used in the TOC -- default is pkg-name
 * `-trace` flag determines if script running is traced
-doc string examples:
+
+An example filter script is:
+```stanza
+val name     = command-line-arguments()[1]
+val filename = command-line-arguments()[2]
+val res =
+  prefix?(filename, "open-components-database/components/") or 
+  prefix?(filename, "open-components-database/modules/") or 
+  prefix?(filename, "open-components-database/utils/")
+println(res)
+```
+
+An example TOC renamer script is:
+```stanza
+val name     = command-line-arguments()[1]
+val filename = command-line-arguments()[2]
+val res =
+  if prefix?(filename, "open-components-database/components/") :
+    replace(name, "ocdb/", "components/")
+  else if prefix?(filename, "open-components-database/modules/") :
+    replace(name, "ocdb/", "modules/")
+  else if prefix?(filename, "open-components-database/utils/") :
+    replace(name, "ocdb/", "utils/")
+  else :
+    name
+println(res)
+```
+
+Doc string examples include:
 ```stanza
 DOC: "makes figures"
 ```
@@ -35,13 +63,13 @@ and
 ```stanza
 DOC: \<s>makes figures<s>
 ```
-where
-  `\<tag>...<tag>` is stanza long comment syntax
-a doc strings can also contain a `FIG:(app, suffix, code)` within
-where app is an app that is called with
+where `\<tag>...<tag>` is the Stanza long comment syntax.
+
+Doc strings can also contain a `FIG:(app, suffix, code)` within
+where `app` is an app that is called with
 * a URL as first arg, fig suffix as second arg, and code as third arg
-app is responsible for running code and producing figure at given URL
-FIG example is:
+App is responsible for running code and producing figure at given URL
+A FIG example is:
 ```stanza
  <img src=FIG:(gen-ocdb-app, svg, view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))) height="50">
 ```
@@ -51,8 +79,12 @@ where
   2. the url suffix (`svg`),
   3. the code string (e.g., `view(URL, two-pin-package(...))`) to run
 * the app (e.g., `gen-ocdb-app`) is expected to bind the variable URL to the URL command line argument so that the
-    the code can access it (e.g., `view(URL, ...)`)
-* `FIG` returns the same url plus the suffix so that it can be used in the enclosing HTML or MD image form
+    the code can access it (e.g., `view(URL, ...)`),
+* `FIG` returns the same url plus the suffix so that it can be used in the enclosing HTML or MD image form, and
+* `gen-ocdb-app.stanza` lives in `open-components-database/utils/` and can be compiled with
+```bash
+stanza open-components-database/utils/gen-ocdb-app.stanza -o build/gen-ocdb
+```
 
 TODO:
 

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -1,6 +1,7 @@
 defpackage stz/auto-doc :
   import core
   import collections
+  import reader
   import stz/namemap
   import stz/compiler
   import stz/front-end
@@ -21,14 +22,15 @@ defpackage stz/auto-doc :
 ;  DOC: \<s>makes figures<s>
 ;where
 ;  \<tag>...<tag> is stanza long comment syntax
-;a doc strings can also contain a FIG:(app, code) within
-;where app is an app that is called with a url as first arg and code as second arg
+;a doc strings can also contain a FIG:(app, suffix, code) within
+;where app is an app that is called with
+;  a url as first arg, suffix as second arg, and code as third arg
 ;app is responsible for running code and producing figure at given url
 ;FIG example is:
-;  <img src=FIG:("gen-pkg-app", view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))).svg height="50">
+;  <img src=FIG:("gen-pkg-app", "svg", view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))) height="50">
 ;where
-;  gen-pkg-app is passed the url to write to minus the svg suffix and
-;  FIG returns the same url, and 
+;  gen-pkg-app is passed the base of the url to write as well as the fig suffix and
+;  FIG returns the same url plus the suffix, and 
 ;  gen-pkg-app binds the variable URL to the passed in URL
 ;
 ;TODO:
@@ -42,9 +44,228 @@ defpackage stz/auto-doc :
 ;     this will need to be revisited so that text can be updated without rerunning all the generation programs.
 
 
+;========================================
+;============ STRING MATCHING ===========
+;========================================
+
+;Matches input str with given wildcard pattern 
+;translated/modified version of https://www.geeksforgeeks.org/wildcard-pattern-matching/
+; Let solutions[i][j] is non false if first i chars in string matches the first j chars of pattern.
+
+defstruct Idx :
+  si : Int
+  pi : Int
+
+defmethod print (o:OutputStream, idx:Idx) :
+  print(o, "[%_ %_]" % [si(idx), pi(idx)])
+
+;Match a string against a pattern returning
+;  false or ordered tuple of string ranges corresponding to wildcard matches
+defn string-match? (str:String, pattern:String) -> False|Tuple<Range> :
+  ;Empty pattern can only match with empty string 
+  if length(pattern) == 0 :
+    [] when length(str) == 0 else false
+
+  else :
+
+    ;Solution table for storing results of subproblems 
+    val solution = Array<Array<False|Idx>>(length(str) + 1)
+    for i in 0 to length(solution) do :
+      solution[i] = Array<False|Idx>(length(pattern) + 1, false)
+
+    ;Empty pattern can match with empty string 
+    solution[0][0] = Idx(0, 0)
+
+    ;Only '*' can match with empty string 
+    for j in 1 through length(pattern) do :
+      if pattern[j - 1] == '*' :
+        if solution[0][j - 1] is Idx :
+          solution[0][j] = Idx(0, j - 1)
+
+    ;Fill the table in bottom-up fashion 
+    for i in 1 through length(str) do :
+      for j in 1 through length(pattern) do :
+        ;Two cases if we see a '*' 
+        ;a) We ignore ‘*’ character and move 
+        ;   to next character in the pattern, 
+        ;    i.e., ‘*’ indicates an empty sequence. 
+        ;b) '*' character matches with ith character in input 
+        if pattern[j - 1] == '*' :
+          if solution[i][j - 1] is Idx :
+            solution[i][j] = Idx(i, j - 1)
+          else if solution[i - 1][j] is Idx :
+            solution[i][j] = Idx(i - 1, j)
+
+        ;Current characters are considered as matching in two cases 
+        ;(a) current character of pattern is '?' 
+        ;(b) characters actually match 
+        else if pattern[j - 1] == '?' or str[i - 1] == pattern[j - 1] :
+          if solution[i - 1][j - 1] is Idx :
+            solution[i][j] = Idx(i - 1, j - 1)
+
+        ;If characters don't match 
+        else :
+          solution[i][j] = false
+
+    ;return string ranges corresponding to wildcard matches in order
+    if solution[length(str)][length(pattern)] is Idx :
+      ; dump(str, pattern, solution)
+      val ends = Array<Int>(length(pattern) + 1, -1)
+      ends[length(pattern)] = length(str) - 1
+      ends[0] = -1
+      ; println("  ENDS %_ = %_" % [length(pattern), length(str) - 1])
+      let loop (idx:False|Idx = solution[length(str)][length(pattern)]) :
+        ; println("IDX %_" % [idx])
+        match(idx) :
+          (idx:Idx) :
+            if pi(idx) > 0 :
+              if ends[pi(idx)] == -1 :
+                ends[pi(idx)] = si(idx) - 1
+                ; println("  ENDS %_ = %_" % [pi(idx), si(idx) - 1])
+              loop(solution[si(idx)][pi(idx)])
+          (idx:False) : false
+      ; println("ENDS %_" % [ends])
+      to-tuple $ generate<Range> :
+        for (c in pattern, i in 1 to false) do :
+          ; println("%_: %_ TO %_" % [i, ends[i - 1] + 1, ends[i]])
+          if c == '*' or c == '?' :
+            yield((ends[i - 1] + 1) through ends[i])
+
+;========================================
+;=========== PATTERN EXPRESSIONS ========
+;========================================
+
+;Used to represent simple string pattern expressions including
+;  matching strings and replacing strings
+;  matching and rules can be combined with logical expressions
+;booleans are represented as False|True|String with true == is-not False
+;  which makes it easier to do logical string expressions
+
+deftype Exp
+defstruct OrOp <: Exp : (x:Exp, y:Exp)
+defstruct AndOp <: Exp : (x:Exp, y:Exp)
+defstruct NotOp <: Exp : (x:Exp)
+defstruct MatchOp <: Exp : (x:Exp, pattern:StringLit)
+defstruct ReplaceOp <: Exp : (x:Exp, pattern:StringLit, replacement:StringLit)
+defstruct Identifier <: Exp : (name:Symbol)
+defstruct StringLit <: Exp : (value:String)
+defstruct RuleOp <: Exp : (matcher:Exp, replacer:Exp)
+
+defmethod print (o:OutputStream, e:Exp) :
+   print{o, _} $ match(e) :
+      (e:OrOp) : "%_ or %_" % [x(e), y(e)]
+      (e:AndOp) : "%_ and %_" % [x(e), y(e)]
+      (e:NotOp) : "not(%_)" % [x(e)]
+      (e:MatchOp) : "match?(%_, %_)" % [x(e), pattern(e)]
+      (e:ReplaceOp) : "replace(%_, %_, %_)" % [x(e), pattern(e), replacement(e)]
+      (e:RuleOp) : "rule(%_, %_)" % [matcher(e), replacer(e)]
+      (e:Identifier) : name(e)
+      (e:StringLit) : "\"%_\"" % [value(e)]
+
+;Eval a patteren expression with a given environment of identifier bindings
+defn string-eval (env:Tuple<KeyValue<Symbol,True|False|String>>, exp:Exp) -> String :
+  eval(env, exp) as String
+
+defn eval (env:Tuple<KeyValue<Symbol,True|False|String>>, exp:Exp) -> False|True|String :
+  match(exp) :
+    (e:Identifier) :
+      lookup(env, name(e))
+    (e:NotOp) :
+      not (eval(env, x(e)) is-not False)
+    (e:OrOp) :
+      val a = eval(env, x(e))
+      a when (a is-not False) else eval(env, y(e))
+    (e:AndOp) :
+      val a = eval(env, x(e))
+      val b = eval(env, y(e))
+      b when (a is-not False and b is-not False)
+    (e:MatchOp) :
+      string-match?(string-eval(env, x(e)), value(pattern(e))) is-not False
+    (e:ReplaceOp) :
+      replace(string-eval(env, x(e)), value(pattern(e)), value(replacement(e)))
+    (e:RuleOp) :
+      if eval(env, matcher(e)) is-not False :
+        string-eval(env, replacer(e))
+
+defsyntax patlang :
+  public defproduction exp: Exp
+  defproduction exp0: Exp
+  defproduction exp1: Exp
+  defproduction term: Exp
+  defproduction stringlit: StringLit
+  defproduction id: Identifier
+
+  defrule exp = (?e:#exp0) : e
+  fail-if exp = () : fatal("Expected an exp here: %_" % [closest-info()])
+
+  defrule exp0 = (?a:#exp0 or ?b:#exp1) : OrOp(a,b)
+  defrule exp0 = (?e:#exp1) : e
+  fail-if exp0 = () : fatal("Expected an exp0 here: %_" % [closest-info()])
+
+  defrule exp1 = (?a:#exp1 and ?b:#term) : AndOp(a,b)
+  defrule exp1 = (not(?a:#exp)) : NotOp(a)
+  defrule exp1 = (?e:#term) : e
+  fail-if exp1 = () : fatal("Expected an exp1 here: %_" % [closest-info()])
+
+  defrule term = ((?e:#exp)) : e
+  defrule term = (match?(?x:#term, ?p:#stringlit)) : MatchOp(x,p)
+  defrule term = (replace(?x:#term, ?p:#stringlit, ?r:#stringlit)) : ReplaceOp(x,p,r)
+  defrule term = (rule(?m:#term, ?r:#term)) : RuleOp(m,r)
+  ; defrule term = (?x:#stringlit) : x
+  defrule term = (?x:#id) : x
+  fail-if term = () : fatal("Expected a term here: %_" % [closest-info()])
+
+  defrule id = (?x) when unwrap-token(x) is Symbol :
+    Identifier(unwrap-token(x))
+
+  defrule stringlit = (?x) when unwrap-token(x) is String :
+    StringLit(unwrap-token(x))
+
+defn read-pattern-exp (filename:False|String, default:Exp) -> Exp :
+  match(filename:String) :
+    val read = read-file(filename)
+    val exps = parse-syntax[patlang / #exp ...](read)
+    next(to-seq $ exps)
+  else :
+    default
+
+;=========================================
+;========== PATHNAMES -> TREE ============
+;=========================================
+
+;String tree node
+defstruct StringTree :
+  key: String
+  children: Tuple<StringTree>
+
+defmethod print (o:OutputStream, node:StringTree) :
+  print(o, "StringTree(%_, %_)" % [key(node), children(node)])
+
+;Turns list of pathname strings into a tree of strings split at slashes
+;  assumes input strings are sorted and trees maintain sorting
+defn organize-strings (strings:Seqable<String>) -> Tuple<StringTree> :
+  val split-strings = to-list $ for s in strings seq : to-list $ split(s, "/")
+  let loop (string-chunkz:List<List<String>> = split-strings) :
+    if empty?(string-chunkz) :
+      []
+    else :
+      val tbl = HashTable<String, List<List<String>>>(List())
+      for chunks in string-chunkz do :
+        if not empty?(chunks) :
+          tbl[head(chunks)] = cons(tail(chunks), tbl[head(chunks)])
+      to-tuple $ lazy-qsort{key, _} $ for kv in tbl seq :
+        StringTree(key(kv), loop(value(kv)))
+
+;=============================================
+;============ DEFINITION PRINTING ============
+;=============================================
+
 ;mangle package name so that it can be used as a filename
+defn mangle (name:String) -> Symbol :
+  to-symbol(replace(name, '/', '$'))
+
 defn mangle (name:Symbol) -> Symbol :
-  to-symbol(replace(to-string(name), '/', '$'))
+  mangle(to-string(name))
 
 ;find all public definitions in ipackage
 defn public-definitions (ipackage:IPackage) -> Seq<IExp> :
@@ -55,7 +276,7 @@ defn public-definitions (ipackage:IPackage) -> Seq<IExp> :
           (e:IBegin) :
             do(loop-public{_, public?}, exps(e))
           (e:IDefn|IDef|IDefChild|IDefType|IDefVar|IDefmulti|IDefmethod|ILSDefn|ILSDefType|ILSDefmethod|IDoc) :
-            yield(e)
+            yield(e) when public?
           (e:IVisibility) :
             loop-public(exp(e), visibility(e) is Public)
           (e) :
@@ -255,8 +476,11 @@ defn parse-items (string:String, tag:String) -> Vector<ParsedItem> :
         add(items, ParsedText(string[start to false]))
   items
 
+val script-counter = to-seq(0 to false)
+
 ;print definition into package file, printing anchors, and recording descriptions for later
-defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable<String>, pkg:IPackage, figs-dir:String) :
+defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable<String>, pkg:IPackage,
+                       figs-dir:String, run-fig-generation?:True|False) :
   match(e) :
     (e:ILSDefType) :
       print-anchor(o, name(e))   
@@ -285,7 +509,6 @@ defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable
     ;   println(o, "`defmethod `%_`%_`" % [lookup-and-link(nm, multi(e)) pretty-args(nm, targs(e), args(e), a1(e) a2(e))])
     (e:IDoc) :
       val str = value(string(e) as ILiteral)
-      val script-counter = to-seq(0 to false)
       for item in parse-items(str, "FIG") do :
         match(item) :
           (item:ParsedText) :
@@ -293,15 +516,17 @@ defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable
           (item:ParsedForm) :
             val id = next(script-counter)
             val script-name = to-string("script%_.stanza" % [id])
-            val filename = to-string("%_/fig-%_" % [name(pkg), id])
-            val pathname = to-string("%_/%_" % [figs-dir, filename])
             val forms = unwrap-all(form(item))
-            val app   = head(forms)
-            val code  = tail(forms)
-            val output = to-string("call-system(\"%_\", [\"%_\", \"%_\", \\<s>%_<s>])" % [app, app, pathname, code])
-            spit(script-name, output)
+            val app    = forms[0]
+            val suffix = forms[1]
+            val code   = tailn(forms, 2)
+            val filename = to-string("%_/fig-%_.%_" % [name(pkg), id, suffix])
+            if run-fig-generation? :
+              val pathname = to-string("%_/%_" % [figs-dir, filename])
+              val output = to-string("call-system(\"%_\", [\"%_\", \"%_\", \\<s>%_<s>])" % [app, app, pathname, code])
+              spit(script-name, output)
+              call-system("stanza", ["stanza", "run", script-name])
             val url = to-string("figs/%_" % [filename])
-            call-system("stanza", ["stanza", "run", script-name])
             print(o, "\"%_\"" % [url])
     (e) :
       false
@@ -336,9 +561,46 @@ defn copy-figs (master-figs-dir:String, package-name:Symbol, info:False|FileInfo
       call-system("sh", ["sh", "-c", string-join $ ["mkdir -p " dst-figs-dir]])
       call-system("sh", ["sh", "-c", string-join $ ["cp " figs-dir "/* " dst-figs-dir]])
 
+;print table of contents using string trees
+defn print-toc (so:OutputStream, start-depth:Int, trees:Tuple<StringTree>, packages:Vector<IPackage>) :
+  var id:Int = -1
+  let loop (depth:Int = start-depth, trees:Tuple<StringTree> = trees, path:List<String> = List()) :
+    for tree in trees do :
+      for i in 0 to (2 * depth) do : print(so, " ")
+      val new-path = cons(key(tree), path)
+      val pkg-name =
+        if empty?(children(tree)) :
+          id = id + 1
+          mangle(name(packages[id]))
+        else :
+          mangle(reduce({ string-join $ [_ "/" _] }, reverse(new-path)))
+      println(so, "- [%_](./packages/%_.md)" % [key(tree), pkg-name])
+      if not empty?(children(tree)) :
+        loop(depth + 1, children(tree), new-path)
+
+;Eval pattern expression binding boolean and pkg identifiers 
+defn eval (pkg:IPackage, exp:Exp, trace?:True|False) -> False|True|String :
+  val env = [to-symbol("true") => true, to-symbol("false") => false,
+             `name => to-string(name(pkg)), `filename => filename(info(pkg) as FileInfo)]
+  val res = eval(env, exp)
+  println("EVAL %_ %_ -> %_" % [env, exp, res]) when trace?
+  res
+
+defn string-eval (pkg:IPackage, exp:Exp, trace?:True|False) -> String :
+  eval(pkg, exp, trace?) as String
+
+defn unzip<?S,?T> (elts:Seqable<KeyValue<?S,?T>>) -> [Vector<S>, Vector<T>] :
+  val ks = Vector<S>()
+  val vs = Vector<T>()
+  for e in elts do :
+    add(ks, key(e))
+    add(vs, value(e))
+  [ks, vs]
+  
+
 ;produce mdbook doc for dir directory using namemap on all given ipackages
 ;outputs summary, package files, and index files
-public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPackage>) :
+public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPackage>, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
   val all-ipackages = to-tuple $ i-all-ipackages
   val dir = string-join $ [md-docs-dir "/src"]
   call-system("sh", ["sh", "-c", string-join $ ["mkdir -p " dir]])
@@ -353,16 +615,29 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
   val functions = IntTable<DefRef>()
   val dt = IntTable<String>()
   val figs-dir = string-join $ [pkg-dir "/figs"]
-  for ipackage in qsort(name, all-ipackages) do :
+  val sorted-packages = to-tuple $ qsort(name, all-ipackages)
+  val env = HashTable<Symbol,String>()
+  val toc-renamer = read-pattern-exp(toc-renamer-filename, Identifier(`name))
+  println("TOC-RENAMER = %_" % [toc-renamer])
+  val pkg-strings = to-tuple $ for pkg in sorted-packages seq : pkg => string-eval(pkg, toc-renamer, trace?)
+  val sorted-pkg-strings = to-tuple $ qsort(value, pkg-strings)
+  val fig-filter = read-pattern-exp(fig-filter-filename, Identifier(to-symbol("true")))
+  println("FIG-FILTER = %_" % [fig-filter])
+  ; val toc-trees = organize-strings(seq({ to-string(name(_)) }, sorted-packages))
+  val [string-sorted-packages, sorted-strings] = unzip $ sorted-pkg-strings
+  val toc-trees = organize-strings(sorted-strings)
+  print-toc(so, 1, toc-trees, string-sorted-packages)
+  for ipackage in sorted-packages do :
+    println("IPACKAGE NAME %_ INFO %_" % [name(ipackage), info(ipackage)])
     copy-figs(figs-dir, name(ipackage), info(ipackage))
-    println(so, "    - [%_](./packages/%_.md)" % [name(ipackage), mangle(name(ipackage))])
     val definitions = to-tuple $ public-definitions(ipackage)
     val pn = string-join $ [pkg-dir "/" mangle(name(ipackage)) ".md"]
     val po = FileOutputStream(pn)
     println(po, "# %_\n" % [name(ipackage)])
     print-defpackage(po, nm, ipackage)
+    val run-fig-generation? = eval(ipackage, fig-filter, trace?) is-not False
     for d in definitions do :
-      print-definition(po, nm, d, dt, ipackage, figs-dir)
+      print-definition(po, nm, d, dt, ipackage, figs-dir, run-fig-generation?)
       collect-definition(name(ipackage), nm, d, types, vars, functions, dt)
       println(po, "")
     println(po, "")
@@ -372,9 +647,25 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
   gen-index(so, dir, "Functions", functions)
   close(so)
 
+;Filter packages based on pkg-filter-filename
+defn match-package-pathnames (ipackages:Seqable<IPackage>, pkg-filter-filename:False|String, trace?:True|False) -> Seqable<IPackage> :
+  val filter-exp = read-pattern-exp(pkg-filter-filename, MatchOp(Identifier(`name), StringLit("*")))
+  for pkg in ipackages filter :
+    match(info(pkg)) :
+      (info:FileInfo) : eval(pkg, filter-exp, trace?) is-not False
+      (info) : false
+
 ;produce mdbook auto-doc in given output directory
-public defn auto-doc (settings:BuildSettings, output:String) :
+;  pkg-filter-filename:  what packages to include
+;  fig-filter-filename:  what packages to generate figures for
+;  toc-renamer-filename: "pathnames" to use for TOC
+;  trace?:               trace pattern expression evaluation?
+public defn auto-doc (settings:BuildSettings, output:String, pkg-filter-filename:False|String, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
   val dep-result = dependencies(settings, true)
   val dir = match(output:String): output else: "docs"
-  gen-doc(dir, namemap(dep-result), filter-by<IPackage>(packages(dep-result)))
+  gen-doc(dir, namemap(dep-result),
+          match-package-pathnames(filter-by<IPackage>(packages(dep-result)), pkg-filter-filename, trace?)
+          fig-filter-filename,
+          toc-renamer-filename,
+          trace?)
 

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -618,17 +618,17 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
   val sorted-packages = to-tuple $ qsort(name, all-ipackages)
   val env = HashTable<Symbol,String>()
   val toc-renamer = read-pattern-exp(toc-renamer-filename, Identifier(`name))
-  println("TOC-RENAMER = %_" % [toc-renamer])
+  println("TOC-RENAMER = %_" % [toc-renamer]) when trace?
   val pkg-strings = to-tuple $ for pkg in sorted-packages seq : pkg => string-eval(pkg, toc-renamer, trace?)
   val sorted-pkg-strings = to-tuple $ qsort(value, pkg-strings)
   val fig-filter = read-pattern-exp(fig-filter-filename, Identifier(to-symbol("true")))
-  println("FIG-FILTER = %_" % [fig-filter])
+  println("FIG-FILTER = %_" % [fig-filter]) when trace?
   ; val toc-trees = organize-strings(seq({ to-string(name(_)) }, sorted-packages))
   val [string-sorted-packages, sorted-strings] = unzip $ sorted-pkg-strings
   val toc-trees = organize-strings(sorted-strings)
   print-toc(so, 1, toc-trees, string-sorted-packages)
   for ipackage in sorted-packages do :
-    println("IPACKAGE NAME %_ INFO %_" % [name(ipackage), info(ipackage)])
+    println("IPACKAGE NAME %_ INFO %_" % [name(ipackage), info(ipackage)]) when trace?
     copy-figs(figs-dir, name(ipackage), info(ipackage))
     val definitions = to-tuple $ public-definitions(ipackage)
     val pn = string-join $ [pkg-dir "/" mangle(name(ipackage)) ".md"]

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -12,46 +12,60 @@ defpackage stz/auto-doc :
   import stz/algorithms
   import stz/proj-manager
 
-;produces mdbook documentation for given ipackages
-;auto-doc refers to generating api information from actual definitions and
-;also includes doc strings which can have markdown (and html) strings
-;example usage:
-;  jstanza doc lib/designs/scratch.stanza -o md-docs -pkg-filter xxx -toc-renamer yyy -fig-filter zzz -trace
-;where
-;  pkg-filter, fig-filter and toc-renamer are scripts that are run with pkg-name pkg-filename as arguments
-;  filters scripts are expected to print to stdout true or false as a string
-;  pkg-filter determines the inclusion of packages -- default is true
-;  fig-filter determines which packages produce figures -- default is true
-;  toc-renamer script is expected to print to stdout a name to be used in the TOC -- default is pkg-name
-;  trace flag determines if script running is traced
-;doc string examples:
-;  DOC: "makes figures"
-;  DOC: \<s>makes figures<s>
-;where
-;  \<tag>...<tag> is stanza long comment syntax
-;a doc strings can also contain a FIG:(app, suffix, code) within
-;where app is an app that is called with
-;  a url as first arg, suffix as second arg, and code as third arg
-;app is responsible for running code and producing figure at given url
-;FIG example is:
-;  <img src=FIG:("gen-ocdb-app", "svg", view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))) height="50">
-;where
-;  gen-ocdb-app is passed the base of the url to write as well as the fig suffix and
-;  FIG returns the same url plus the suffix, and 
-;  gen-pkg-app binds the variable URL to the passed in URL
-;
-;TODO:
-;
-; o Move pretty-printer out to general mechanism.
-;     There some tricky nuances involving precedence and operator associativity.
-;     Look at the type printer in stz-type to see how precedence is handled.
-;     Hopefully, can be refactored together with the pretty-printer into the same mechanism.
-; o parse-iterms is fine for now. Has some bad performance characteristics that we can revisit later.
-; o the FIG processing currently runs as part of running stanza doc,
-;     this will need to be revisited so that text can be updated without rerunning all the generation programs.
+;<DOC>=======================================================================
+auto-doc produces mdbook documentation for requested Stanza packages.
+auto-doc refers to generating API information from actual definitions as well as
+doc strings which can have markdown (and html) strings.
+Example usage:
+```bash
+jstanza doc lib/designs/scratch.stanza -o md-docs -pkg-filter xxx -toc-renamer yyy -fig-filter zzz -trace
+```
+where
+* pkg-filter, fig-filter and toc-renamer are scripts that are run with pkg-name and pkg-filename as arguments
+* filters scripts are expected to print to stdout `true` or `false` as a string
+* pkg-filter determines the inclusion of packages -- default is `true`
+* fig-filter determines which packages produce figures -- default is `true`
+* toc-renamer script is expected to print to stdout a name to be used in the TOC -- default is pkg-name
+* `-trace` flag determines if script running is traced
+doc string examples:
+```stanza
+DOC: "makes figures"
+```
+and
+```stanza
+DOC: \<s>makes figures<s>
+```
+where
+  `\<tag>...<tag>` is stanza long comment syntax
+a doc strings can also contain a `FIG:(app, suffix, code)` within
+where app is an app that is called with
+* a URL as first arg, fig suffix as second arg, and code as third arg
+app is responsible for running code and producing figure at given URL
+FIG example is:
+```stanza
+ <img src=FIG:(gen-ocdb-app, svg, view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))) height="50">
+```
+where
+* `gen-ocdb-app` is run with command line arguments of
+  1. the base of the url to write and
+  2. the url suffix (`svg`),
+  3. the code string (e.g., `view(URL, two-pin-package(...))`) to run
+* the app (e.g., `gen-ocdb-app`) is expected to bind the variable URL to the URL command line argument so that the
+    the code can access it (e.g., `view(URL, ...)`)
+* `FIG` returns the same url plus the suffix so that it can be used in the enclosing HTML or MD image form
+
+TODO:
+
+ o Move pretty-printer out to general mechanism.
+     There some tricky nuances involving precedence and operator associativity.
+     Look at the type printer in stz-type to see how precedence is handled.
+     Hopefully, can be refactored together with the pretty-printer into the same mechanism.
+ o parse-iterms is fine for now. Has some bad performance characteristics that we can revisit later.
+ o the FIG processing currently runs as part of running stanza doc,
+     this will need to be revisited so that text can be updated without rerunning all the generation programs.
+;============================================================================== <DOC>
 
 defn call-plugin (name:String, arguments:Seqable<String>) -> False|String :
-  println("CALLING PLUGIN %_ %_" % [name, arguments])
   val proc = Process(name, cat([name], arguments), PROCESS-IN, PROCESS-OUT, PROCESS-ERR)
   ; println("WRITING HELLO")
   ; println(input-stream(proc), "\"HELLO\"")
@@ -379,7 +393,7 @@ defn print-definition (o:OutputStream, nm:NameMap, e:IExp, descriptions:IntTable
             val filename = to-string("%_/fig-%_.%_" % [name(pkg), id, suffix])
             if run-fig-generation? :
               val pathname = to-string("%_/%_" % [figs-dir, filename])
-              val output = to-string("call-system(\"%_\", [\"%_\", \"%_\", \\<s>%_<s>])" % [app, app, pathname, code])
+              val output = to-string("call-system(\"%_\", [\"%_\", \"%_\", \"%_\", \\<s>%_<s>])" % [app, app, pathname, suffix, code])
               spit(script-name, output)
               call-system("stanza", ["stanza", "run", script-name])
             val url = to-string("figs/%_" % [filename])
@@ -446,7 +460,6 @@ defn unzip<?S,?T> (elts:Seqable<KeyValue<?S,?T>>) -> [Vector<S>, Vector<T>] :
 ;produce mdbook doc for dir directory using namemap on all given ipackages
 ;outputs summary, package files, and index files
 public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPackage>, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
-  println("ENTERING GEN-DOC")
   val all-ipackages = to-tuple $ i-all-ipackages
   val dir = string-join $ [md-docs-dir "/src"]
   call-system("sh", ["sh", "-c", string-join $ ["mkdir -p " dir]])
@@ -494,10 +507,7 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
 defn match-package-pathnames (ipackages:Seqable<IPackage>, pkg-filter-filename:False|String, trace?:True|False) -> Seqable<IPackage> :
   for pkg in ipackages filter :
     match(info(pkg)) :
-      (info:FileInfo) :
-        val res = call-boolean-plugin(pkg-filter-filename, pkg, { true }, trace?)
-        println("CALLED BOOLEAN PLUGIN -> %_" % [res])
-        res
+      (info:FileInfo) : call-boolean-plugin(pkg-filter-filename, pkg, { true }, trace?)
       (info) : false
 
 ;produce mdbook auto-doc in given output directory

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -98,6 +98,7 @@ TODO:
  o add timeout check for plugin execution
  o add support for special characters in package pathnames
  o add proper delete directory command that handles windows and escaping etc
+ o would be good to factor print-definitions into creating datastructure and then processing/printing
 ;============================================================================== <DOC>
 
 public defstruct AutoDocPluginOutputException <: Exception :
@@ -139,7 +140,7 @@ public defstruct AutoDocPluginBooleanException <: Exception :
   response: String
 
 defmethod print (o:OutputStream, e:AutoDocPluginBooleanException) :
-  print("Read invalid response %_ from boolean plugin %_" % [response(e), name(e)])
+  print(o, "Read invalid response %_ from boolean plugin %_" % [response(e), name(e)])
 
 defn call-boolean-plugin (name:String, args:Seqable<String>) -> True|False :
   val response = call-string-plugin(name, args)

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -43,191 +43,40 @@ defpackage stz/auto-doc :
 ; o the FIG processing currently runs as part of running stanza doc,
 ;     this will need to be revisited so that text can be updated without rerunning all the generation programs.
 
+defn call-plugin (name:String, arguments:Seqable<String>) -> False|String :
+  println("CALLING PLUGIN %_ %_" % [name, arguments])
+  val proc = Process(name, cat([name], arguments), PROCESS-IN, PROCESS-OUT, PROCESS-ERR)
+  ; println("WRITING HELLO")
+  ; println(input-stream(proc), "\"HELLO\"")
+  ; flush(input-stream(proc))
+  val tokens = read-line(output-stream(proc))
+  val response = match(tokens:List<Token>) :
+    unwrap-token(head(tokens)) when not empty?(tokens)
+  wait(proc)
+  response
 
-;========================================
-;============ STRING MATCHING ===========
-;========================================
+defn call-string-plugin (name:String, args:Seqable<String>) -> String :
+  to-string(call-plugin(name, args))
 
-;Matches input str with given wildcard pattern 
-;translated/modified version of https://www.geeksforgeeks.org/wildcard-pattern-matching/
-; Let solutions[i][j] is non false if first i chars in string matches the first j chars of pattern.
+defn call-boolean-plugin (name:String, args:Seqable<String>) -> True|False :
+  val response = call-string-plugin(name, args)
+  response == "true"
 
-defstruct Idx :
-  si : Int
-  pi : Int
+defn call-string-plugin (app-name:False|String, pkg:IPackage, default:IPackage -> String, trace?:True|False) -> String :
+  val res =
+    match(app-name:String) :
+      call-string-plugin(app-name, [to-string(name(pkg)), filename(info(pkg) as FileInfo)])
+    else : default(pkg)
+  println("CALL %_ PKG-NAME %_ PKG-FILENAME %_ RES %_" % [app-name, name(pkg), filename(info(pkg) as FileInfo), res]) when trace?
+  res
 
-defmethod print (o:OutputStream, idx:Idx) :
-  print(o, "[%_ %_]" % [si(idx), pi(idx)])
-
-;Match a string against a pattern returning
-;  false or ordered tuple of string ranges corresponding to wildcard matches
-defn string-match? (str:String, pattern:String) -> False|Tuple<Range> :
-  ;Empty pattern can only match with empty string 
-  if length(pattern) == 0 :
-    [] when length(str) == 0 else false
-
-  else :
-
-    ;Solution table for storing results of subproblems 
-    val solution = Array<Array<False|Idx>>(length(str) + 1)
-    for i in 0 to length(solution) do :
-      solution[i] = Array<False|Idx>(length(pattern) + 1, false)
-
-    ;Empty pattern can match with empty string 
-    solution[0][0] = Idx(0, 0)
-
-    ;Only '*' can match with empty string 
-    for j in 1 through length(pattern) do :
-      if pattern[j - 1] == '*' :
-        if solution[0][j - 1] is Idx :
-          solution[0][j] = Idx(0, j - 1)
-
-    ;Fill the table in bottom-up fashion 
-    for i in 1 through length(str) do :
-      for j in 1 through length(pattern) do :
-        ;Two cases if we see a '*' 
-        ;a) We ignore ‘*’ character and move 
-        ;   to next character in the pattern, 
-        ;    i.e., ‘*’ indicates an empty sequence. 
-        ;b) '*' character matches with ith character in input 
-        if pattern[j - 1] == '*' :
-          if solution[i][j - 1] is Idx :
-            solution[i][j] = Idx(i, j - 1)
-          else if solution[i - 1][j] is Idx :
-            solution[i][j] = Idx(i - 1, j)
-
-        ;Current characters are considered as matching in two cases 
-        ;(a) current character of pattern is '?' 
-        ;(b) characters actually match 
-        else if pattern[j - 1] == '?' or str[i - 1] == pattern[j - 1] :
-          if solution[i - 1][j - 1] is Idx :
-            solution[i][j] = Idx(i - 1, j - 1)
-
-        ;If characters don't match 
-        else :
-          solution[i][j] = false
-
-    ;return string ranges corresponding to wildcard matches in order
-    if solution[length(str)][length(pattern)] is Idx :
-      ; dump(str, pattern, solution)
-      val ends = Array<Int>(length(pattern) + 1, -1)
-      ends[length(pattern)] = length(str) - 1
-      ends[0] = -1
-      ; println("  ENDS %_ = %_" % [length(pattern), length(str) - 1])
-      let loop (idx:False|Idx = solution[length(str)][length(pattern)]) :
-        ; println("IDX %_" % [idx])
-        match(idx) :
-          (idx:Idx) :
-            if pi(idx) > 0 :
-              if ends[pi(idx)] == -1 :
-                ends[pi(idx)] = si(idx) - 1
-                ; println("  ENDS %_ = %_" % [pi(idx), si(idx) - 1])
-              loop(solution[si(idx)][pi(idx)])
-          (idx:False) : false
-      ; println("ENDS %_" % [ends])
-      to-tuple $ generate<Range> :
-        for (c in pattern, i in 1 to false) do :
-          ; println("%_: %_ TO %_" % [i, ends[i - 1] + 1, ends[i]])
-          if c == '*' or c == '?' :
-            yield((ends[i - 1] + 1) through ends[i])
-
-;========================================
-;=========== PATTERN EXPRESSIONS ========
-;========================================
-
-;Used to represent simple string pattern expressions including
-;  matching strings and replacing strings
-;  matching and rules can be combined with logical expressions
-;booleans are represented as False|True|String with true == is-not False
-;  which makes it easier to do logical string expressions
-
-deftype Exp
-defstruct OrOp <: Exp : (x:Exp, y:Exp)
-defstruct AndOp <: Exp : (x:Exp, y:Exp)
-defstruct NotOp <: Exp : (x:Exp)
-defstruct MatchOp <: Exp : (x:Exp, pattern:StringLit)
-defstruct ReplaceOp <: Exp : (x:Exp, pattern:StringLit, replacement:StringLit)
-defstruct Identifier <: Exp : (name:Symbol)
-defstruct StringLit <: Exp : (value:String)
-defstruct RuleOp <: Exp : (matcher:Exp, replacer:Exp)
-
-defmethod print (o:OutputStream, e:Exp) :
-   print{o, _} $ match(e) :
-      (e:OrOp) : "%_ or %_" % [x(e), y(e)]
-      (e:AndOp) : "%_ and %_" % [x(e), y(e)]
-      (e:NotOp) : "not(%_)" % [x(e)]
-      (e:MatchOp) : "match?(%_, %_)" % [x(e), pattern(e)]
-      (e:ReplaceOp) : "replace(%_, %_, %_)" % [x(e), pattern(e), replacement(e)]
-      (e:RuleOp) : "rule(%_, %_)" % [matcher(e), replacer(e)]
-      (e:Identifier) : name(e)
-      (e:StringLit) : "\"%_\"" % [value(e)]
-
-;Eval a patteren expression with a given environment of identifier bindings
-defn string-eval (env:Tuple<KeyValue<Symbol,True|False|String>>, exp:Exp) -> String :
-  eval(env, exp) as String
-
-defn eval (env:Tuple<KeyValue<Symbol,True|False|String>>, exp:Exp) -> False|True|String :
-  match(exp) :
-    (e:Identifier) :
-      lookup(env, name(e))
-    (e:NotOp) :
-      not (eval(env, x(e)) is-not False)
-    (e:OrOp) :
-      val a = eval(env, x(e))
-      a when (a is-not False) else eval(env, y(e))
-    (e:AndOp) :
-      val a = eval(env, x(e))
-      val b = eval(env, y(e))
-      b when (a is-not False and b is-not False)
-    (e:MatchOp) :
-      string-match?(string-eval(env, x(e)), value(pattern(e))) is-not False
-    (e:ReplaceOp) :
-      replace(string-eval(env, x(e)), value(pattern(e)), value(replacement(e)))
-    (e:RuleOp) :
-      if eval(env, matcher(e)) is-not False :
-        string-eval(env, replacer(e))
-
-defsyntax patlang :
-  public defproduction exp: Exp
-  defproduction exp0: Exp
-  defproduction exp1: Exp
-  defproduction term: Exp
-  defproduction stringlit: StringLit
-  defproduction id: Identifier
-
-  defrule exp = (?e:#exp0) : e
-  fail-if exp = () : fatal("Expected an exp here: %_" % [closest-info()])
-
-  defrule exp0 = (?a:#exp0 or ?b:#exp1) : OrOp(a,b)
-  defrule exp0 = (?e:#exp1) : e
-  fail-if exp0 = () : fatal("Expected an exp0 here: %_" % [closest-info()])
-
-  defrule exp1 = (?a:#exp1 and ?b:#term) : AndOp(a,b)
-  defrule exp1 = (not(?a:#exp)) : NotOp(a)
-  defrule exp1 = (?e:#term) : e
-  fail-if exp1 = () : fatal("Expected an exp1 here: %_" % [closest-info()])
-
-  defrule term = ((?e:#exp)) : e
-  defrule term = (match?(?x:#term, ?p:#stringlit)) : MatchOp(x,p)
-  defrule term = (replace(?x:#term, ?p:#stringlit, ?r:#stringlit)) : ReplaceOp(x,p,r)
-  defrule term = (rule(?m:#term, ?r:#term)) : RuleOp(m,r)
-  ; defrule term = (?x:#stringlit) : x
-  defrule term = (?x:#id) : x
-  fail-if term = () : fatal("Expected a term here: %_" % [closest-info()])
-
-  defrule id = (?x) when unwrap-token(x) is Symbol :
-    Identifier(unwrap-token(x))
-
-  defrule stringlit = (?x) when unwrap-token(x) is String :
-    StringLit(unwrap-token(x))
-
-defn read-pattern-exp (filename:False|String, default:Exp) -> Exp :
-  match(filename:String) :
-    val read = read-file(filename)
-    val exps = parse-syntax[patlang / #exp ...](read)
-    next(to-seq $ exps)
-  else :
-    default
+defn call-boolean-plugin (app-name:False|String, pkg:IPackage, default:IPackage -> True|False, trace?:True|False) -> True|False :
+  val res =
+    match(app-name:String) :
+      call-string-plugin(app-name, [to-string(name(pkg)), filename(info(pkg) as FileInfo)]) == "true"
+    else : default(pkg)
+  println("CALL %_ PKG-NAME %_ PKG-FILENAME %_ RES %_" % [app-name, name(pkg), filename(info(pkg) as FileInfo), res]) when trace?
+  res
 
 ;=========================================
 ;========== PATHNAMES -> TREE ============
@@ -578,17 +427,6 @@ defn print-toc (so:OutputStream, start-depth:Int, trees:Tuple<StringTree>, packa
       if not empty?(children(tree)) :
         loop(depth + 1, children(tree), new-path)
 
-;Eval pattern expression binding boolean and pkg identifiers 
-defn eval (pkg:IPackage, exp:Exp, trace?:True|False) -> False|True|String :
-  val env = [to-symbol("true") => true, to-symbol("false") => false,
-             `name => to-string(name(pkg)), `filename => filename(info(pkg) as FileInfo)]
-  val res = eval(env, exp)
-  println("EVAL %_ %_ -> %_" % [env, exp, res]) when trace?
-  res
-
-defn string-eval (pkg:IPackage, exp:Exp, trace?:True|False) -> String :
-  eval(pkg, exp, trace?) as String
-
 defn unzip<?S,?T> (elts:Seqable<KeyValue<?S,?T>>) -> [Vector<S>, Vector<T>] :
   val ks = Vector<S>()
   val vs = Vector<T>()
@@ -601,6 +439,7 @@ defn unzip<?S,?T> (elts:Seqable<KeyValue<?S,?T>>) -> [Vector<S>, Vector<T>] :
 ;produce mdbook doc for dir directory using namemap on all given ipackages
 ;outputs summary, package files, and index files
 public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPackage>, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
+  println("ENTERING GEN-DOC")
   val all-ipackages = to-tuple $ i-all-ipackages
   val dir = string-join $ [md-docs-dir "/src"]
   call-system("sh", ["sh", "-c", string-join $ ["mkdir -p " dir]])
@@ -617,12 +456,9 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
   val figs-dir = string-join $ [pkg-dir "/figs"]
   val sorted-packages = to-tuple $ qsort(name, all-ipackages)
   val env = HashTable<Symbol,String>()
-  val toc-renamer = read-pattern-exp(toc-renamer-filename, Identifier(`name))
-  println("TOC-RENAMER = %_" % [toc-renamer]) when trace?
-  val pkg-strings = to-tuple $ for pkg in sorted-packages seq : pkg => string-eval(pkg, toc-renamer, trace?)
+  val pkg-strings = to-tuple $ for pkg in sorted-packages seq :
+    pkg => call-string-plugin(toc-renamer-filename, pkg, { to-string(name(_)) }, trace?)
   val sorted-pkg-strings = to-tuple $ qsort(value, pkg-strings)
-  val fig-filter = read-pattern-exp(fig-filter-filename, Identifier(to-symbol("true")))
-  println("FIG-FILTER = %_" % [fig-filter]) when trace?
   ; val toc-trees = organize-strings(seq({ to-string(name(_)) }, sorted-packages))
   val [string-sorted-packages, sorted-strings] = unzip $ sorted-pkg-strings
   val toc-trees = organize-strings(sorted-strings)
@@ -635,7 +471,7 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
     val po = FileOutputStream(pn)
     println(po, "# %_\n" % [name(ipackage)])
     print-defpackage(po, nm, ipackage)
-    val run-fig-generation? = eval(ipackage, fig-filter, trace?) is-not False
+    val run-fig-generation? = call-boolean-plugin(fig-filter-filename, ipackage, { true }, trace?)
     for d in definitions do :
       print-definition(po, nm, d, dt, ipackage, figs-dir, run-fig-generation?)
       collect-definition(name(ipackage), nm, d, types, vars, functions, dt)
@@ -649,10 +485,12 @@ public defn gen-doc (md-docs-dir:String, nm:NameMap, i-all-ipackages:Seqable<IPa
 
 ;Filter packages based on pkg-filter-filename
 defn match-package-pathnames (ipackages:Seqable<IPackage>, pkg-filter-filename:False|String, trace?:True|False) -> Seqable<IPackage> :
-  val filter-exp = read-pattern-exp(pkg-filter-filename, MatchOp(Identifier(`name), StringLit("*")))
   for pkg in ipackages filter :
     match(info(pkg)) :
-      (info:FileInfo) : eval(pkg, filter-exp, trace?) is-not False
+      (info:FileInfo) :
+        val res = call-boolean-plugin(pkg-filter-filename, pkg, { true }, trace?)
+        println("CALLED BOOLEAN PLUGIN -> %_" % [res])
+        res
       (info) : false
 
 ;produce mdbook auto-doc in given output directory

--- a/compiler/stz-auto-doc.stanza
+++ b/compiler/stz-auto-doc.stanza
@@ -13,10 +13,17 @@ defpackage stz/auto-doc :
   import stz/proj-manager
 
 ;produces mdbook documentation for given ipackages
-;auto-doc refers to generating api information from actual definitions
+;auto-doc refers to generating api information from actual definitions and
 ;also includes doc strings which can have markdown (and html) strings
 ;example usage:
-;  stanza doc infinity-mirror-3dp -o md-docs
+;  jstanza doc lib/designs/scratch.stanza -o md-docs -pkg-filter xxx -toc-renamer yyy -fig-filter zzz -trace
+;where
+;  pkg-filter, fig-filter and toc-renamer are scripts that are run with pkg-name pkg-filename as arguments
+;  filters scripts are expected to print to stdout true or false as a string
+;  pkg-filter determines the inclusion of packages -- default is true
+;  fig-filter determines which packages produce figures -- default is true
+;  toc-renamer script is expected to print to stdout a name to be used in the TOC -- default is pkg-name
+;  trace flag determines if script running is traced
 ;doc string examples:
 ;  DOC: "makes figures"
 ;  DOC: \<s>makes figures<s>
@@ -27,9 +34,9 @@ defpackage stz/auto-doc :
 ;  a url as first arg, suffix as second arg, and code as third arg
 ;app is responsible for running code and producing figure at given url
 ;FIG example is:
-;  <img src=FIG:("gen-pkg-app", "svg", view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))) height="50">
+;  <img src=FIG:("gen-ocdb-app", "svg", view(URL, two-pin-package(0.35, 0.10, 0.14, 0.35, 0.14))) height="50">
 ;where
-;  gen-pkg-app is passed the base of the url to write as well as the fig suffix and
+;  gen-ocdb-app is passed the base of the url to write as well as the fig suffix and
 ;  FIG returns the same url plus the suffix, and 
 ;  gen-pkg-app binds the variable URL to the passed in URL
 ;

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -681,7 +681,11 @@ defn auto-doc (parsed:ParseResult) :
     ensure-non-empty-input!()
     ensure-supported-platform!()
     val output = single(parsed, "o")
-    auto-doc(build-settings(), output)
+    val pkg-filter = single?(parsed, "pkg-filter", false)
+    val fig-filter = single?(parsed, "fig-filter", false)
+    val toc-renamer = single?(parsed, "toc-renamer", false)
+    val trace? = has-flag?(parsed, "trace")
+    auto-doc(build-settings(), output, pkg-filter, fig-filter, toc-renamer, trace?)
 
   defn ensure-non-empty-input! () :
     if empty?(args(parsed)) :
@@ -735,6 +739,10 @@ defn auto-doc (parsed:ParseResult) :
 public val DOC-COMMAND =
   Command("doc", [
     SingleFlag("o", false),
+    SingleFlag("pkg-filter", true),
+    SingleFlag("fig-filter", true),
+    SingleFlag("toc-renamer", true),
+    MarkerFlag("trace"),
     SingleFlag("platform", true),
     MarkerFlag("build-target"),
     MultipleFlag("pkg", 0, 1, true),


### PR DESCRIPTION
add more options such as filtering on packages that are included, renaming of names for TOC, filtering on packages for which figures are generated, and tracing of calls to scripts.  scripts are now used for these operations with pkg name and filename passed as command line arguments and with the resulting string printed to standard output being the result (either true/false for filters or string for renaming).  the TOC is now generated as a hierarchy based on the TOC "pathname".