### PR TITLE
allow private in scope level expressions

### DIFF
--- a/compiler/stz-il-ir.stanza
+++ b/compiler/stz-il-ir.stanza
@@ -578,17 +578,16 @@ public defn Begin (es:List<IExp>, info:False|FileInfo) :
 ;Flatten and remove private expressions
 ;Adds only a single level of flattening and assumes nested levels are already flattened
 public defn scope-flatten (es:List<IExp>) :
-  for e in es seq-append :
-    match(e:IBegin) :
-      for ex in exps(e) seq-append :
-        match(ex:IVisibility) :
-          if visibility(ex) is Private :
-            match(exp(ex)) :
-              (e:IBegin) : exps(e)
-              (e) : List(e)
-          else : List(ex)
-        else: List(ex)
-    else: List(e)
+   for e in es seq-append :
+      match(e) :
+         (e:IBegin) :
+           scope-flatten(exps(e))
+         (e:IVisibility) :
+           if visibility(e) is Private :
+             scope-flatten(List(exp(e)))
+           else :
+             List(e)
+         (e) : List(e)
 
 public defn ScopeBegin (es:List<IExp>, info:False|FileInfo) :
    val es* = scope-flatten(es)

--- a/compiler/stz-il-ir.stanza
+++ b/compiler/stz-il-ir.stanza
@@ -580,7 +580,7 @@ public defn Begin (es:List<IExp>, info:False|FileInfo) :
 public defn scope-flatten (es:List<IExp>) :
    for e in es seq-append :
       match(e) :
-         (e:IBegin) : exps(e)
+         (e:IBegin) : scope-flatten(exps(e))
          (e:IVisibility) :
            if visibility(e) is Private :
              scope-flatten(List(exp(e)))

--- a/compiler/stz-il-ir.stanza
+++ b/compiler/stz-il-ir.stanza
@@ -565,24 +565,27 @@ public defn subexps (e:IExp) -> Collection<IExp> & Lengthable :
 public defn flatten (es:List<IExp>) :
    for e in es seq-append :
       match(e) :
-         (e:IBegin) : flatten(exps(e))
+         (e:IBegin) : exps(e)
          (e) : List(e)
 
+;Adds only a single level of flattening and assumes nested levels are already flattened
 public defn Begin (es:List<IExp>, info:False|FileInfo) :
    val es* = flatten(es)
    if empty?(es*) : IBegin(es*, info)
    else if empty?(tail(es*)) : head(es*)
    else : IBegin(es*, info)
 
-;Flatten and remove/check visibility expressions
+;Flatten and remove private expressions
+;Adds only a single level of flattening and assumes nested levels are already flattened
 public defn scope-flatten (es:List<IExp>) :
    for e in es seq-append :
       match(e) :
-         (e:IBegin) : scope-flatten(exps(e))
+         (e:IBegin) : exps(e)
          (e:IVisibility) :
-           if visibility(e) is-not Private :
-             lang/check/error!(info(e), "Only Private visibility allowed in scope-level expressions.")
-           scope-flatten(List(exp(e)))
+           if visibility(e) is Private :
+             scope-flatten(List(exp(e)))
+           else :
+             List(e)
          (e) : List(e)
 
 public defn ScopeBegin (es:List<IExp>, info:False|FileInfo) :

--- a/compiler/stz-il-ir.stanza
+++ b/compiler/stz-il-ir.stanza
@@ -578,15 +578,17 @@ public defn Begin (es:List<IExp>, info:False|FileInfo) :
 ;Flatten and remove private expressions
 ;Adds only a single level of flattening and assumes nested levels are already flattened
 public defn scope-flatten (es:List<IExp>) :
-   for e in es seq-append :
-      match(e) :
-         (e:IBegin) : scope-flatten(exps(e))
-         (e:IVisibility) :
-           if visibility(e) is Private :
-             scope-flatten(List(exp(e)))
-           else :
-             List(e)
-         (e) : List(e)
+  for e in es seq-append :
+    match(e:IBegin) :
+      for ex in exps(e) seq-append :
+        match(ex:IVisibility) :
+          if visibility(ex) is Private :
+            match(exp(ex)) :
+              (e:IBegin) : exps(e)
+              (e) : List(e)
+          else : List(ex)
+        else: List(ex)
+    else: List(e)
 
 public defn ScopeBegin (es:List<IExp>, info:False|FileInfo) :
    val es* = scope-flatten(es)

--- a/compiler/stz-il-ir.stanza
+++ b/compiler/stz-il-ir.stanza
@@ -565,11 +565,28 @@ public defn subexps (e:IExp) -> Collection<IExp> & Lengthable :
 public defn flatten (es:List<IExp>) :
    for e in es seq-append :
       match(e) :
-         (e:IBegin) : exps(e)
+         (e:IBegin) : flatten(exps(e))
          (e) : List(e)
 
 public defn Begin (es:List<IExp>, info:False|FileInfo) :
    val es* = flatten(es)
+   if empty?(es*) : IBegin(es*, info)
+   else if empty?(tail(es*)) : head(es*)
+   else : IBegin(es*, info)
+
+;Flatten and remove/check visibility expressions
+public defn scope-flatten (es:List<IExp>) :
+   for e in es seq-append :
+      match(e) :
+         (e:IBegin) : scope-flatten(exps(e))
+         (e:IVisibility) :
+           if visibility(e) is-not Private :
+             lang/check/error!(info(e), "Only Private visibility allowed in scope-level expressions.")
+           scope-flatten(List(exp(e)))
+         (e) : List(e)
+
+public defn ScopeBegin (es:List<IExp>, info:False|FileInfo) :
+   val es* = scope-flatten(es)
    if empty?(es*) : IBegin(es*, info)
    else if empty?(tail(es*)) : head(es*)
    else : IBegin(es*, info)

--- a/compiler/stz-input.stanza
+++ b/compiler/stz-input.stanza
@@ -74,13 +74,13 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
       ($prefix p:e) :
          IPrefixExp(false, p, info)
       ($public e:e es:e ...) :
-         val es* = ScopeBegin(e, es, info)
+         val es* = Begin(e, es, info)
          IVisibility(es*, Public(), info)
       ($protected e:e es:e ...) :
-         val es* = ScopeBegin(e, es, info)
+         val es* = Begin(e, es, info)
          IVisibility(es*, Protected(), info)
       ($private e:e es:e ...) :
-         val es* = ScopeBegin(e, es, info)
+         val es* = Begin(e, es, info)
          IVisibility(es*, Private(), info)
       ;Stanza Declaration Forms
       ($doc string:e) :

--- a/compiler/stz-input.stanza
+++ b/compiler/stz-input.stanza
@@ -58,6 +58,7 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
       (e) : [e, List()]
 
 ;Scope-level bodies include:
+;  $private, $public, $protected
 ;  $defn, $defn*, $defmethod, $defmethod*, $fn, $fn*, $branch,
 ;  $ls-letexp, $ls-block, $ls-let, $ls-branch,
 ;  $ls-defn, $ls-extern-fn, $ls-defn*, $ls-defmethod, $ls-defmethod*, 
@@ -73,13 +74,13 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
       ($prefix p:e) :
          IPrefixExp(false, p, info)
       ($public e:e es:e ...) :
-         val es* = Begin(e, es, info)
+         val es* = ScopeBegin(e, es, info)
          IVisibility(es*, Public(), info)
       ($protected e:e es:e ...) :
-         val es* = Begin(e, es, info)
+         val es* = ScopeBegin(e, es, info)
          IVisibility(es*, Protected(), info)
       ($private e:e es:e ...) :
-         val es* = Begin(e, es, info)
+         val es* = ScopeBegin(e, es, info)
          IVisibility(es*, Private(), info)
       ;Stanza Declaration Forms
       ($doc string:e) :

--- a/compiler/stz-input.stanza
+++ b/compiler/stz-input.stanza
@@ -44,6 +44,9 @@ public defn exported-types (ps:Tuple<IPackage>) :
 defn Begin (e:IExp, es:List<IExp>, info:False|FileInfo) :
    Begin(cons(e, es), info)
 
+defn ScopeBegin (e:IExp, es:List<IExp>, info:False|FileInfo) :
+   ScopeBegin(cons(e, es), info)
+
 defn name-args (e:IExp) -> [IExp, List<IExp>] :
    match(e) :
       (e:IOf) : [class(e), args(e)]
@@ -54,6 +57,10 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
       (e:ILSOfT) : [class(e), args(e)]
       (e) : [e, List()]
 
+;Scope-level bodies include:
+;  $defn, $defn*, $defmethod, $defmethod*, $fn, $fn*, $branch,
+;  $ls-letexp, $ls-block, $ls-let, $ls-branch,
+;  $ls-defn, $ls-extern-fn, $ls-defn*, $ls-defmethod, $ls-defmethod*, 
 #with-added-syntax(stz-reader-lang) :
    defreader read-iexp (e) -> IExp :
       ;Package Forms
@@ -89,30 +96,30 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
          IDefVar(name, type, value, info)      
       ($defn name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [name*, targs*] = name-args(name)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IDefn(false, name*, targs*, a1, a2, args, body, info)
       ($defn* name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [name*, targs*] = name-args(name)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IDefn(true, name*, targs*, a1, a2, args, body, info)         
       ($defmulti name:e (a1:e ...) a2:e) :
          val [name*, targs*] = name-args(name)
          IDefmulti(name*, targs*, a1, a2, info)
       ($defmethod name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [name*, targs*] = name-args(name)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IDefmethod(false, name*, false, targs*, a1, a2, args, body, info)
       ($defmethod* name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [name*, targs*] = name-args(name)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IDefmethod(true, name*, false, targs*, a1, a2, args, body, info)
          
       ;Stanza Expression Forms
       ($fn (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IFn(false, a1, a2, args, body, info)
       ($fn* (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IFn(true, a1, a2, args, body, info)
       ($multi f:e fs:e ...) :
          IMulti(cons(f, fs), info)
@@ -124,7 +131,7 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
       ($match (es:e ...) bs:e ...) :
          IMatch(es, bs, info)
       ($branch (args:e ...) (ts:e ...) body0:e bodyn:e ...) :
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          IBranch(ts, args, body, info)
       ($new type:e methods:e ...) :
          INew(type, methods, info)
@@ -194,9 +201,9 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
          ILSAs(exp, type, info)
       ($ls-letexp e:e es:e ...) :
          val es* = flatten(cons(e, es))
-         val empty = Begin(List(), info)
+         val empty = ScopeBegin(List(), info)
          if empty?(es*) : ILSLetExp(empty, empty, info)
-         else : ILSLetExp(Begin(but-last(es*), info), last(es*), info)
+         else : ILSLetExp(ScopeBegin(but-last(es*), info), last(es*), info)
       ($ls-and a:e b:e) :
          ILSAnd(a, b, info)
       ($ls-or a:e b:e) :
@@ -208,21 +215,21 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
       ($ls-labels blocks:e ...) :
          ILSLabels(blocks, info)
       ($ls-block name:e (args:e ...) (ts:e ...) body0:e bodyn:e ...) :
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSLabeledBlock(name, args, ts, body, info)
       ($ls-goto name:e args:e ...) :
          ILSGoto(name, args, info)         
       ($ls-return e:e) :
          ILSReturn(e, info)
       ($ls-let c:e cs:e ...) :
-         val c* = Begin(c, cs, info)
+         val c* = ScopeBegin(c, cs, info)
          ILSLet(c*, info)
       ($ls-if p:e c:e a:e) :
          ILSIf(p, c, a, info)
       ($ls-match (args:e ...) bs:e ...) :
          ILSMatch(args, bs, info)
       ($ls-branch (args:e ...) (ts:e ...) body0:e bodyn:e ...) :
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSBranch(ts, args, body, info)
       ($ls-func x:e) :
          ILSFn(x, info)
@@ -239,22 +246,22 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
          ILSDefType(name*, args*, parent, fs, fr, info)
       ($ls-defn name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [name*, targs*] = ls-name-args(name)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSDefn(false, name*, targs*, a1, a2, args, body, info)
       ($ls-extern-fn name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSExternFn(name, a1, a2, args, body, info)
       ($ls-defn* name:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [name*, targs*] = ls-name-args(name)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSDefn(true, name*, targs*, a1, a2, args, body, info)
       ($ls-defmethod multi:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [multi*, targs*] = ls-name-args(multi)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSDefmethod(false, multi*, targs*, a1, a2, args, body, info)
       ($ls-defmethod* multi:e (args:e ...) (a1:e ...) a2:e body0:e bodyn:e ...) :
          val [multi*, targs*] = ls-name-args(multi)
-         val body = Begin(body0, bodyn, info)
+         val body = ScopeBegin(body0, bodyn, info)
          ILSDefmethod(true, multi*, targs*, a1, a2, args, body, info)
       ($ls-extern name:e type:e) :
          ILSExtern(name, type, info)


### PR DESCRIPTION
changed read-iexp to allow private wrappers around scope-level expressions.