### PR TITLE
Improve granularity of the definitions database

### DIFF
--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -18,14 +18,27 @@ public public defenum SrcDefinitionSource :
   SrcDefinition
 
 public defstruct Definition : 
-  name:      Symbol
+  name:      String,
   file-info: FileInfo 
   kind:      SrcDefinitionKind 
   source:    SrcDefinitionSource
 
 public defstruct DefinitionsDatabase: 
-  keywords: Tuple<String>, 
+  reserved-words: Tuple<String>, 
   definitions: HashTable<String, List<Definition>>
+
+defstruct IDefinition : 
+  file-info: FileInfo 
+  kind:      Int
+  source:    Int
+
+defstruct IDefinitionRecord: 
+  name: String, 
+  definitions: Tuple<IDefinition>
+
+defstruct IDefinitionsDatabase: 
+  reserved-words: Tuple<String>, 
+  definitions: Tuple<IDefinitionRecord>
 
 public defstruct DefsDB :
   reserved-words : Tuple<String>
@@ -43,11 +56,119 @@ defstruct DefRec :
   name : String
   infos : List<FileInfo>
 
-public defserializer (out:OutputStream, in:InputStream) :
+public defserializer (out:OutputStream, in:InputStream) : 
+  defunion idefinitions-database (IDefinitionsDatabase) :
+    IDefinitionsDatabase : (reserved-words:tuple(string), definitions:tuple(idefinition-record))
 
+  defunion idefinition-record (IDefinitionRecord):
+    IDefinitionRecord : (name:string, definitions:tuple(idefinition))
+
+  defunion idefinition (IDefinition) : 
+    IDefinition : (file-info:fileinfo, kind:int, source:int)
+  
+  defunion fileinfo (FileInfo) :
+    FileInfo : (filename:string, line:int, column:int)
+
+  reader defn read-table<?K,?V> (k: () -> ?K, v: () -> ?V) :
+    val n = read-int()
+    to-hashtable<K,V> $ for i in 0 to n seq : k() => v()
+
+  writer defn write-table<?K,?V> (k: K -> False, v: V -> False, tbl:HashTable<?K,?V>) :
+    write-int(length(tbl))
+    for e in tbl do :
+      k(key(e))
+      v(value(e))
+
+  reader defn read-list<?T> (f: () -> ?T) :
+    val n = read-int()
+    to-list(repeatedly(f, n))
+
+  writer defn write-list<?T> (f: T -> False, xs:List<?T>) :
+    write-int(length(xs))
+    do(f, xs)
+  
+  reader defn read-tuple<?T> (f: () -> ?T) :
+    val n = read-int()
+    to-tuple(repeatedly(f, n))
+
+  writer defn write-tuple<?T> (f: T -> False, xs:Tuple<?T>) :
+    write-int(length(xs))
+    do(f, xs)
+  
+  defatom lit (x:?) :
+    writer :
+      match(x) :
+        (x:Char) :
+          write-byte(0Y)
+          write-char(x)
+        (x:Byte) :
+          write-byte(1Y)
+          write-byte(x)
+        (x:Int) :
+          write-byte(2Y)
+          write-int(x)
+        (x:String) :
+          write-byte(3Y)
+          write-string(x)
+        (x:List) :
+          write-byte(4Y)
+          write-list(write-lit, x)
+        (x:Tuple) :
+          write-byte(5Y)
+          write-tuple(write-lit, x)
+    reader :
+      switch(read-byte()) :
+        0Y : read-char()
+        1Y : read-byte()
+        2Y : read-int()
+        3Y : read-string()
+        4Y : read-list(read-lit)
+        5Y : read-tuple(read-lit)
+        else : throw(DeserializeException())
+
+  defatom byte (x:Byte) :
+    writer :
+      put(out, x)
+    reader :
+      match(get-byte(in)) :
+        (x:Byte) : x
+        (x:False) : throw(DeserializeException())
+
+  defatom char (x:Char) :
+    writer :
+      print(out, x)
+    reader :
+      match(get-char(in)) :
+        (x:Char) : x
+        (x:False) : throw(DeserializeException())
+
+  defatom int (x:Int) :
+    writer :
+      to-var-int(x, put{out, _})
+    reader :
+      from-var-int(read-byte)
+
+  defatom string (x:String) :
+    writer :
+      write-int(length(x))
+      print(out, x)
+    reader :
+      val n = read-int()
+      String(repeatedly(read-char, n))
+
+public defserializer (out:OutputStream, in:InputStream) : 
   defunion idefsdb (IDefsDB) :
     IDefsDB : (ireserved-words:tuple(string), ipackages:tuple(string), ipkg-id-defs:tuple(defrec), iid-defs:tuple(defrec)) 
 
+  defunion idefinitions-database (IDefinitionsDatabase) :
+    IDefinitionsDatabase : (reserved-words:tuple(string), definitions:tuple(idefinition-record))
+
+  defunion idefinition-record (IDefinitionRecord):
+    IDefinitionRecord : (name:string, definitions:tuple(idefinition))
+
+  defunion idefinition (IDefinition) : 
+    IDefinition : (file-info:fileinfo, kind:int, source:int)
+  
   defunion defrec (DefRec) :
     DefRec : (name:string, infos:list(fileinfo))
 
@@ -184,9 +305,60 @@ public defn serialize (out:OutputStream, db:DefsDB) :
                     to-tuple $ qsort{name, _} $ for e in id-defs(db) seq : DefRec(key(e), value(e)))
   serialize(out, idb)
 
+public defn serialize (out:OutputStream, ddb:DefinitionsDatabase) :
+  val definitions = to-tuple $
+    for kv in definitions $ ddb seq : 
+      val name = key(kv)
+      val defs = to-tuple $
+        for def in value(kv) seq : 
+          IDefinition(
+            file-info(def), 
+            to-int(kind(def)), 
+            to-int(source(def)),
+          )
+      IDefinitionRecord(name, defs)
+  val iddb = IDefinitionsDatabase(
+    reserved-words(ddb), 
+    definitions,
+  )
+  serialize(out, iddb)
+
 public defn deserialize (in:InputStream) -> DefsDB :
   val db = deserialize-idefsdb(in) as IDefsDB
   DefsDB(ireserved-words(db),
          ipackages(db),
          to-hashtable<String,List<FileInfo>> $ for def in ipkg-id-defs(db) seq : name(def) => infos(def),
          to-hashtable<String,List<FileInfo>> $ for def in iid-defs(db) seq : name(def) => infos(def))
+
+public defn deserialize-ddb (in:InputStream) -> DefinitionsDatabase : 
+  val iddb = deserialize-idefinitions-database(in) as IDefinitionsDatabase
+  val reserved-words = reserved-words(iddb)   ; Tuple<String> 
+  val idefinition-records = definitions(iddb) ; List<IDefinitionRecord> 
+  val definitions =  ;HashTable<String, List<Definition>>(List())
+    to-hashtable<String, List<Definition>> $ 
+      for idefrec in idefinition-records seq : 
+        val name  = name(idefrec) ; String
+        val idefs = definitions(idefrec) ; List<IDefinition> 
+        var defs  = List()
+        for idef in idefs do : 
+          val definition = Definition(
+            name, 
+            file-info(idef),
+            SrcDefinitionKind(kind(idef)),
+            SrcDefinitionSource(source(idef)),
+          )
+          defs = cons(definition, defs)
+        name => defs
+  DefinitionsDatabase(reserved-words, definitions)
+
+defmethod print (o:OutputStream, kind:SrcDefinitionKind):
+  val string = 
+    match(kind):
+      (_:SrcDefUnknown):  "unknown", 
+      (_:SrcDefMulti):    "multi", 
+      (_:SrcDefMethod):   "method", 
+      (_:SrcDefFunction): "function", 
+      (_:SrcDefVariable): "variable", 
+      (_:SrcDefType):     "type", 
+      (_:SrcDefPackage):  "package",
+  print(o, string)

--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -1,15 +1,37 @@
 #use-added-syntax(stz-serializer-lang)
-
 defpackage stz/defs-db-serializer :
   import core
   import collections
   import stz/serializer
 
+public defenum SrcDefinitionKind : 
+  SrcDefUnknown
+  SrcDefMulti 
+  SrcDefMethod 
+  SrcDefFunction 
+  SrcDefVariable
+  SrcDefType
+  SrcDefPackage
+
+public public defenum SrcDefinitionSource : 
+  PkgDefinition 
+  SrcDefinition
+
+public defstruct Definition : 
+  name:      Symbol
+  file-info: FileInfo 
+  kind:      SrcDefinitionKind 
+  source:    SrcDefinitionSource
+
+public defstruct DefinitionsDatabase: 
+  keywords: Tuple<String>, 
+  definitions: HashTable<String, List<Definition>>
+
 public defstruct DefsDB :
   reserved-words : Tuple<String>
   packages : Tuple<String>
-  pkg-id-defs : HashTable<String,List<FileInfo>>
-  id-defs : HashTable<String,List<FileInfo>>
+  pkg-id-defs : HashTable<String, List<FileInfo>>
+  id-defs : HashTable<String, List<FileInfo>>
 
 defstruct IDefsDB :
   ireserved-words : Tuple<String>
@@ -168,4 +190,3 @@ public defn deserialize (in:InputStream) -> DefsDB :
          ipackages(db),
          to-hashtable<String,List<FileInfo>> $ for def in ipkg-id-defs(db) seq : name(def) => infos(def),
          to-hashtable<String,List<FileInfo>> $ for def in iid-defs(db) seq : name(def) => infos(def))
-

--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -12,72 +12,41 @@ public defenum SrcDefinitionKind :
   SrcDefVariable
   SrcDefType
   SrcDefPackage
-
+  
 public public defenum SrcDefinitionSource : 
   PkgDefinition 
   SrcDefinition
 
 public defstruct Definition : 
-  name:      String,
+  name:      Symbol,
   file-info: FileInfo 
   kind:      SrcDefinitionKind 
   source:    SrcDefinitionSource
 
 public defstruct DefinitionsDatabase: 
   reserved-words: Tuple<String>, 
-  definitions: HashTable<String, List<Definition>>
-
-defstruct IDefinition : 
-  file-info: FileInfo 
-  kind:      Int
-  source:    Int
-
-defstruct IDefinitionRecord: 
-  name: String, 
-  definitions: Tuple<IDefinition>
-
-defstruct IDefinitionsDatabase: 
-  reserved-words: Tuple<String>, 
-  definitions: Tuple<IDefinitionRecord>
-
-public defstruct DefsDB :
-  reserved-words : Tuple<String>
-  packages : Tuple<String>
-  pkg-id-defs : HashTable<String, List<FileInfo>>
-  id-defs : HashTable<String, List<FileInfo>>
-
-defstruct IDefsDB :
-  ireserved-words : Tuple<String>
-  ipackages : Tuple<String>
-  ipkg-id-defs : Tuple<DefRec>
-  iid-defs : Tuple<DefRec>
-
-defstruct DefRec :
-  name : String
-  infos : List<FileInfo>
+  definitions: HashTable<Symbol, List<Definition>>
 
 public defserializer (out:OutputStream, in:InputStream) : 
-  defunion idefinitions-database (IDefinitionsDatabase) :
-    IDefinitionsDatabase : (reserved-words:tuple(string), definitions:tuple(idefinition-record))
+  defunion definitions-database (DefinitionsDatabase) :
+    DefinitionsDatabase : (reserved-words:tuple(string), definitions:table)
 
-  defunion idefinition-record (IDefinitionRecord):
-    IDefinitionRecord : (name:string, definitions:tuple(idefinition))
-
-  defunion idefinition (IDefinition) : 
-    IDefinition : (file-info:fileinfo, kind:int, source:int)
+  defunion definition (Definition) : 
+    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src)
   
   defunion fileinfo (FileInfo) :
     FileInfo : (filename:string, line:int, column:int)
 
-  reader defn read-table<?K,?V> (k: () -> ?K, v: () -> ?V) :
+  reader defn read-table () :
     val n = read-int()
-    to-hashtable<K,V> $ for i in 0 to n seq : k() => v()
+    to-hashtable<Symbol, List<Definition>> $ 
+      for i in 0 to n seq : read-symbol() => read-list(read-definition)
 
-  writer defn write-table<?K,?V> (k: K -> False, v: V -> False, tbl:HashTable<?K,?V>) :
+  writer defn write-table (tbl:HashTable<Symbol, List<Definition>>) :
     write-int(length(tbl))
     for e in tbl do :
-      k(key(e))
-      v(value(e))
+      write-symbol(key(e))
+      write-list(write-definition, value(e))
 
   reader defn read-list<?T> (f: () -> ?T) :
     val n = read-int()
@@ -94,37 +63,32 @@ public defserializer (out:OutputStream, in:InputStream) :
   writer defn write-tuple<?T> (f: T -> False, xs:Tuple<?T>) :
     write-int(length(xs))
     do(f, xs)
-  
-  defatom lit (x:?) :
+
+  defatom src-def-src (x:SrcDefinitionSource): 
+    writer: 
+      put(out, to-int(x))
+    reader : 
+      val i = read-int()
+      val max-index = to-int(SrcDefinition)
+      if i < 0 or i >= max-index : 
+        throw(DeserializeException())
+      SrcDefinitionSource(i)
+
+  defatom src-def-kind (x:SrcDefinitionKind) :
     writer :
-      match(x) :
-        (x:Char) :
-          write-byte(0Y)
-          write-char(x)
-        (x:Byte) :
-          write-byte(1Y)
-          write-byte(x)
-        (x:Int) :
-          write-byte(2Y)
-          write-int(x)
-        (x:String) :
-          write-byte(3Y)
-          write-string(x)
-        (x:List) :
-          write-byte(4Y)
-          write-list(write-lit, x)
-        (x:Tuple) :
-          write-byte(5Y)
-          write-tuple(write-lit, x)
+      put(out, to-int(x))
     reader :
-      switch(read-byte()) :
-        0Y : read-char()
-        1Y : read-byte()
-        2Y : read-int()
-        3Y : read-string()
-        4Y : read-list(read-lit)
-        5Y : read-tuple(read-lit)
-        else : throw(DeserializeException())
+      val i = read-int()
+      val max-index = to-int(SrcDefPackage)
+      if i < 0 or i >= max-index :
+        throw(DeserializeException())
+      SrcDefinitionKind(i)
+  
+  defatom symbol (x:Symbol) :
+    writer :
+      write-string(to-string(x))
+    reader :
+      to-symbol(read-string())
 
   defatom byte (x:Byte) :
     writer :
@@ -142,12 +106,6 @@ public defserializer (out:OutputStream, in:InputStream) :
         (x:Char) : x
         (x:False) : throw(DeserializeException())
 
-  defatom int (x:Int) :
-    writer :
-      to-var-int(x, put{out, _})
-    reader :
-      from-var-int(read-byte)
-
   defatom string (x:String) :
     writer :
       write-int(length(x))
@@ -156,203 +114,17 @@ public defserializer (out:OutputStream, in:InputStream) :
       val n = read-int()
       String(repeatedly(read-char, n))
 
-public defserializer (out:OutputStream, in:InputStream) : 
-  defunion idefsdb (IDefsDB) :
-    IDefsDB : (ireserved-words:tuple(string), ipackages:tuple(string), ipkg-id-defs:tuple(defrec), iid-defs:tuple(defrec)) 
-
-  defunion idefinitions-database (IDefinitionsDatabase) :
-    IDefinitionsDatabase : (reserved-words:tuple(string), definitions:tuple(idefinition-record))
-
-  defunion idefinition-record (IDefinitionRecord):
-    IDefinitionRecord : (name:string, definitions:tuple(idefinition))
-
-  defunion idefinition (IDefinition) : 
-    IDefinition : (file-info:fileinfo, kind:int, source:int)
-  
-  defunion defrec (DefRec) :
-    DefRec : (name:string, infos:list(fileinfo))
-
-  defunion fileinfo (FileInfo) :
-    FileInfo : (filename:string, line:int, column:int)
-
-  reader defn read-table<?K,?V> (k: () -> ?K, v: () -> ?V) :
-    val n = read-int()
-    to-hashtable<K,V> $ for i in 0 to n seq : k() => v()
-
-  writer defn write-table<?K,?V> (k: K -> False, v: V -> False, tbl:HashTable<?K,?V>) :
-    write-int(length(tbl))
-    for e in tbl do :
-      k(key(e))
-      v(value(e))
-
-  reader defn read-list<?T> (f: () -> ?T) :
-    val n = read-int()
-    to-list(repeatedly(f, n))
-
-  writer defn write-list<?T> (f: T -> False, xs:List<?T>) :
-    write-int(length(xs))
-    do(f, xs)
-  
-  reader defn read-tuple<?T> (f: () -> ?T) :
-    val n = read-int()
-    to-tuple(repeatedly(f, n))
-
-  writer defn write-tuple<?T> (f: T -> False, xs:Tuple<?T>) :
-    write-int(length(xs))
-    do(f, xs)
-  
-  defatom lit (x:?) :
-    writer :
-      match(x) :
-        (x:Char) :
-          write-byte(0Y)
-          write-char(x)
-        (x:Byte) :
-          write-byte(1Y)
-          write-byte(x)
-        (x:Int) :
-          write-byte(2Y)
-          write-int(x)
-        (x:String) :
-          write-byte(3Y)
-          write-string(x)
-        (x:List) :
-          write-byte(4Y)
-          write-list(write-lit, x)
-        (x:Tuple) :
-          write-byte(5Y)
-          write-tuple(write-lit, x)
-    reader :
-      switch(read-byte()) :
-        0Y : read-char()
-        1Y : read-byte()
-        2Y : read-int()
-        3Y : read-string()
-        4Y : read-list(read-lit)
-        5Y : read-tuple(read-lit)
-        else : throw(DeserializeException())
-
-  defatom byte (x:Byte) :
-    writer :
-      put(out, x)
-    reader :
-      match(get-byte(in)) :
-        (x:Byte) : x
-        (x:False) : throw(DeserializeException())
-
-  defatom char (x:Char) :
-    writer :
+  defatom int (x:Int): 
+    writer: 
       print(out, x)
-    reader :
-      match(get-char(in)) :
-        (x:Char) : x
-        (x:False) : throw(DeserializeException())
+    reader : 
+      read-int()
 
-  defatom int (x:Int) :
-    writer :
-      to-var-int(x, put{out, _})
-    reader :
-      from-var-int(read-byte)
-
-  defatom string (x:String) :
-    writer :
-      write-int(length(x))
-      print(out, x)
-    reader :
-      val n = read-int()
-      String(repeatedly(read-char, n))
-
-
-defn to-var-int (x:Int, Y: Byte -> False) :
-  defn B0 (x:Int) : Y(to-byte(x))
-  defn B1 (x:Int) : Y(to-byte(x >> 8))
-  defn B2 (x:Int) : Y(to-byte(x >> 16))
-  defn B3 (x:Int) : Y(to-byte(x >> 24))
-  if x >= 0 :
-    if x < 250 : B0(x)
-    else if x < 506 : (Y(250Y), B0(x - 250))
-    else if x < 762 : (Y(251Y), B0(x - 506))
-    else if x < 1018 : (Y(252Y), B0(x - 762))
-    else if x < 32768 : (Y(253Y), B1(x), B0(x))
-    else if x < 8388608 : (Y(254Y), B2(x), B1(x), B0(x))
-    else : (Y(255Y), B3(x), B2(x), B1(x), B0(x))
-  else :
-    if x >= -32768 : (Y(253Y), B1(x), B0(x))
-    else if x >= -8388608 : (Y(254Y), B2(x), B1(x), B0(x))
-    else : (Y(255Y), B3(x), B2(x), B1(x), B0(x))
-
-defn from-var-int (N: () -> Byte) -> Int :
-  defn B0 () : to-int(N())
-  defn B1 () : B0() << 8
-  defn B2 () : B0() << 16
-  defn S1 () : (B0() << 24) >>> 16
-  defn S2 () : (B0() << 24) >>> 8
-  defn S3 () : (B0() << 24)
-
-  val x = N()
-  switch(x) :
-    255Y : S3() | B2() | B1() | B0()
-    254Y : S2() | B1() | B0()
-    253Y : S1() | B0()
-    252Y : B0() + 762
-    251Y : B0() + 506
-    250Y : B0() + 250
-    else : to-int(x)
-
-public defn serialize (out:OutputStream, db:DefsDB) :
-  val idb = IDefsDB(reserved-words(db), packages(db),
-                    to-tuple $ qsort{name, _} $ for e in pkg-id-defs(db) seq : DefRec(key(e), value(e))
-                    to-tuple $ qsort{name, _} $ for e in id-defs(db) seq : DefRec(key(e), value(e)))
-  serialize(out, idb)
-
-public defn serialize (out:OutputStream, ddb:DefinitionsDatabase) :
-  val definitions = to-tuple $
-    for kv in definitions $ ddb seq : 
-      val name = key(kv)
-      val defs = to-tuple $
-        for def in value(kv) seq : 
-          IDefinition(
-            file-info(def), 
-            to-int(kind(def)), 
-            to-int(source(def)),
-          )
-      IDefinitionRecord(name, defs)
-  val iddb = IDefinitionsDatabase(
-    reserved-words(ddb), 
-    definitions,
-  )
-  serialize(out, iddb)
-
-public defn deserialize (in:InputStream) -> DefsDB :
-  val db = deserialize-idefsdb(in) as IDefsDB
-  DefsDB(ireserved-words(db),
-         ipackages(db),
-         to-hashtable<String,List<FileInfo>> $ for def in ipkg-id-defs(db) seq : name(def) => infos(def),
-         to-hashtable<String,List<FileInfo>> $ for def in iid-defs(db) seq : name(def) => infos(def))
-
-public defn deserialize-ddb (in:InputStream) -> DefinitionsDatabase : 
-  val iddb = deserialize-idefinitions-database(in) as IDefinitionsDatabase
-  val reserved-words = reserved-words(iddb)   ; Tuple<String> 
-  val idefinition-records = definitions(iddb) ; List<IDefinitionRecord> 
-  val definitions =  ;HashTable<String, List<Definition>>(List())
-    to-hashtable<String, List<Definition>> $ 
-      for idefrec in idefinition-records seq : 
-        val name  = name(idefrec) ; String
-        val idefs = definitions(idefrec) ; List<IDefinition> 
-        var defs  = List()
-        for idef in idefs do : 
-          val definition = Definition(
-            name, 
-            file-info(idef),
-            SrcDefinitionKind(kind(idef)),
-            SrcDefinitionSource(source(idef)),
-          )
-          defs = cons(definition, defs)
-        name => defs
-  DefinitionsDatabase(reserved-words, definitions)
+public defn read-definitions-database (in:InputStream) -> DefinitionsDatabase : 
+  deserialize-definitions-database(in) as DefinitionsDatabase
 
 defmethod print (o:OutputStream, kind:SrcDefinitionKind):
-  val string = 
+  print{o, _} $ 
     match(kind):
       (_:SrcDefUnknown):  "unknown", 
       (_:SrcDefMulti):    "multi", 
@@ -361,4 +133,3 @@ defmethod print (o:OutputStream, kind:SrcDefinitionKind):
       (_:SrcDefVariable): "variable", 
       (_:SrcDefType):     "type", 
       (_:SrcDefPackage):  "package",
-  print(o, string)

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -25,6 +25,7 @@ public defstruct DefsDbInput :
   platform: Symbol|False
   flags: Tuple<Symbol>
   optimize?: True|False
+  extra?: True|False 
 
 public defn defs-db (input:DefsDbInput, filename:String) :
   ;Compute platform
@@ -55,8 +56,12 @@ public defn defs-db (input:DefsDbInput, filename:String) :
   ;Compute dependencies
   val dep-result = dependencies(build-settings, true)
 
-  ;Call generation of definitions database.
-  gen-defs-db(filename, namemap(dep-result), packages(dep-result))
+  ;Call generation of definitions database
+  if extra?(input) : 
+    gen-defs-db-2(filename, namemap(dep-result), packages(dep-result))
+  else : 
+    gen-defs-db(filename, namemap(dep-result), packages(dep-result))
+
 
 ;============================================================
 ;============= Retrieve All Packages in Proj File ===========
@@ -127,7 +132,7 @@ defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> 
         match(info:FileInfo) :
           match(lookup(nm, name)) :
             (name:Symbol) : 
-              yield $ Definition(name, info, kindof(exp), SrcDefinition)
+              yield $ Definition(to-string $ name, info, kindof(exp), SrcDefinition)
             (o) : false
       match(exp) :
         (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti) :
@@ -143,7 +148,7 @@ defn collect-public-definitions (packageio:PackageIO) -> Seq<Definition> :
   generate<Definition> :
     defn add-def (name:Symbol, info:False|FileInfo) :
       match(info:FileInfo) : 
-        yield $ Definition(name, info, SrcDefUnknown, PkgDefinition)
+        yield $ Definition(to-string $ name, info, SrcDefUnknown, PkgDefinition)
 
     for e in exports(packageio) do :
       if visibility(e) is Public :
@@ -168,6 +173,20 @@ val stanza-reserved-words = [
   "?" "of" "ptr" "ref"
   ]
 
+public defn gen-defs-db-2 (
+  out-path: String, 
+  name-map:    NameMap,
+  packages: Seqable<IPackage|Pkg>
+):
+  val all-definitions = HashTable<String, List<Definition>>(List())
+  for package in packages do : 
+    val definitions = to-tuple $ public-definitions(package, name-map)
+    for def in definitions do : 
+      val name = name(def)
+      all-definitions[name] = cons(def, all-definitions[name])
+  val ddb = DefinitionsDatabase(stanza-reserved-words, all-definitions)
+  serialize(FileOutputStream $ out-path, ddb)
+
 public defn gen-defs-db (defs-db:String, nm:NameMap, i-all-packages:Seqable<IPackage|Pkg>) :
   val all-packages = to-tuple $ i-all-packages
   val packages = Vector<String>()
@@ -178,7 +197,7 @@ public defn gen-defs-db (defs-db:String, nm:NameMap, i-all-packages:Seqable<IPac
     add(packages, pkg-name)
     val definitions = to-tuple $ public-definitions(package, nm)
     for def in definitions do :
-      val name = to-string(name(def))
+      val name = name(def)
       val info = file-info(def)
       id-defs[name] = cons(info, id-defs[name])
       val package-name = string-join $ [pkg-name "/" name]

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -25,7 +25,6 @@ public defstruct DefsDbInput :
   platform: Symbol|False
   flags: Tuple<Symbol>
   optimize?: True|False
-  extra?: True|False 
 
 public defn defs-db (input:DefsDbInput, filename:String) :
   ;Compute platform
@@ -57,10 +56,7 @@ public defn defs-db (input:DefsDbInput, filename:String) :
   val dep-result = dependencies(build-settings, true)
 
   ;Call generation of definitions database
-  if extra?(input) : 
-    gen-defs-db-2(filename, namemap(dep-result), packages(dep-result))
-  else : 
-    gen-defs-db(filename, namemap(dep-result), packages(dep-result))
+  gen-defs-db(filename, namemap(dep-result), packages(dep-result))
 
 
 ;============================================================
@@ -132,7 +128,7 @@ defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> 
         match(info:FileInfo) :
           match(lookup(nm, name)) :
             (name:Symbol) : 
-              yield $ Definition(to-string $ name, info, kindof(exp), SrcDefinition)
+              yield $ Definition(name, info, kindof(exp), SrcDefinition)
             (o) : false
       match(exp) :
         (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti) :
@@ -148,7 +144,7 @@ defn collect-public-definitions (packageio:PackageIO) -> Seq<Definition> :
   generate<Definition> :
     defn add-def (name:Symbol, info:False|FileInfo) :
       match(info:FileInfo) : 
-        yield $ Definition(to-string $ name, info, SrcDefUnknown, PkgDefinition)
+        yield $ Definition(name, info, SrcDefUnknown, PkgDefinition)
 
     for e in exports(packageio) do :
       if visibility(e) is Public :
@@ -173,38 +169,19 @@ val stanza-reserved-words = [
   "?" "of" "ptr" "ref"
   ]
 
-public defn gen-defs-db-2 (
+public defn gen-defs-db (
   out-path: String, 
   name-map:    NameMap,
   packages: Seqable<IPackage|Pkg>
 ):
-  val all-definitions = HashTable<String, List<Definition>>(List())
+  val all-definitions = HashTable<Symbol, List<Definition>>(List())
   for package in packages do : 
     val definitions = to-tuple $ public-definitions(package, name-map)
     for def in definitions do : 
       val name = name(def)
-      all-definitions[name] = cons(def, all-definitions[name])
+      update(all-definitions, cons{def, _}, name)
   val ddb = DefinitionsDatabase(stanza-reserved-words, all-definitions)
-  serialize(FileOutputStream $ out-path, ddb)
-
-public defn gen-defs-db (defs-db:String, nm:NameMap, i-all-packages:Seqable<IPackage|Pkg>) :
-  val all-packages = to-tuple $ i-all-packages
-  val packages = Vector<String>()
-  val id-defs = HashTable<String,List<FileInfo>>(List())
-  val pkg-id-defs = HashTable<String,List<FileInfo>>(List())
-  for package in all-packages do :
-    val pkg-name = to-string $ name(package)
-    add(packages, pkg-name)
-    val definitions = to-tuple $ public-definitions(package, nm)
-    for def in definitions do :
-      val name = name(def)
-      val info = file-info(def)
-      id-defs[name] = cons(info, id-defs[name])
-      val package-name = string-join $ [pkg-name "/" name]
-      match(package:IPackage):
-        pkg-id-defs[package-name] = cons(info, pkg-id-defs[package-name])
-
-  val o = FileOutputStream $ defs-db
-  val db = DefsDB(stanza-reserved-words, to-tuple $ packages, pkg-id-defs, id-defs)
-  serialize(o, db)
-  close(o)
+  val ostream = FileOutputStream(out-path)
+  serialize(ostream, ddb)
+  close(ostream)
+  

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -69,19 +69,33 @@ defn all-packages (proj-file:ProjFile) -> Tuple<Symbol> :
 ;============================================================
 ;============================================================
 ;============================================================
+public defmulti kindof (e:IExp) 
+public defmethod kindof (e:IExp):
+  SrcDefUnknown
+  
+public defmethod kindof (e:IDefmulti): 
+  SrcDefMulti
+public defmethod kindof (e:IDefmethod|ILSDefmethod): 
+  SrcDefMethod
+public defmethod kindof (e:IDefn|ILSDefn): 
+  SrcDefFunction
+public defmethod kindof (e:IDefType|ILSDefType): 
+  SrcDefType
+; public defmethod kindof (e:IPackage|Pkg): 
+;   SrcDefPackage
 
 defstruct DefRec :
   name: Symbol
   info: FileInfo
 
-defmulti public-definitions (pkg:IPackage|Pkg, nm:NameMap) -> Seq<DefRec>
+defmulti public-definitions (pkg:IPackage|Pkg, nm:NameMap) -> Seq<Definition>
 
 defn lookup (nm:NameMap, e:IExp) -> False|Symbol :
   match(e:VarN) : name(nm[n(e)])
   else: false
 
 ;find all public definitions in ipackage
-defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<DefRec> :
+defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> :
   val exps = generate<IExp> :
     defn loop (e:IExp) :
       defn* loop-public (e:IExp, public?:True|False) :
@@ -107,12 +121,13 @@ defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<DefRec> :
           false
     for e in exps(ipackage) do :
       loop(e)
-  generate<DefRec> :
+  generate<Definition> :
     for exp in exps do :
       defn add-def (name:IExp, info:False|FileInfo) :
         match(info:FileInfo) :
           match(lookup(nm, name)) :
-            (name:Symbol) : yield $ DefRec(name, info)
+            (name:Symbol) : 
+              yield $ Definition(name, info, kindof(exp), SrcDefinition)
             (o) : false
       match(exp) :
         (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti) :
@@ -124,28 +139,30 @@ defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<DefRec> :
         (e) :
           false
     
-defn collect-public-definitions (packageio:PackageIO) -> Seq<DefRec> :
-  generate<DefRec> :
+defn collect-public-definitions (packageio:PackageIO) -> Seq<Definition> :
+  generate<Definition> :
     defn add-def (name:Symbol, info:False|FileInfo) :
-      match(info:FileInfo) : yield $ DefRec(name, info)
+      match(info:FileInfo) : 
+        yield $ Definition(name, info, SrcDefUnknown, PkgDefinition)
+
     for e in exports(packageio) do :
       if visibility(e) is Public :
         add-def(name(id(rec(e))), info(e))
 
-defmethod public-definitions (pkg:FastPkg, nm:NameMap) -> Seq<DefRec> :
+defmethod public-definitions (pkg:FastPkg, nm:NameMap) -> Seq<Definition> :
   collect-public-definitions(packageio(pkg))
 
-defmethod public-definitions (pkg:StdPkg, nm:NameMap) -> Seq<DefRec> :
+defmethod public-definitions (pkg:StdPkg, nm:NameMap) -> Seq<Definition> :
   collect-public-definitions(packageio(vmp(pkg)))
 
 val stanza-reserved-words = [
   "package" "import" "prefix-of" "prefix" "public" "protected" "private" "doc" "deftype" "defchild" "def"
-  "defvar" "defn" "defn*" "defmulti" "defmethod" "defmethod*" "fn" "fn*"
+  "defpackage" "defvar" "defn" "defn*" "defmulti" "defmethod" "defmethod*" "fn" "fn*"
   "multi" "begin" "let" "match" "branch" "new" "as" "as?" "set" "do"
   "prim" "tuple" "quote" "none" "of" "and" "or" "->" 
   "cap" "void" "new" "struct" "addr" "addr!" "deref"
   "slot" "field" "do" "call-c" "prim" "sizeof" "tagof" 
-  "letexp" "and" "or" "set" "labels" "block" "goto" "return"
+  "letexp" "and" "or" "set" "label" "labels" "block" "goto" "return"
   "let" "if" "match" "branch" "func" "def" "defvar" "deftype" "deffield"
   "extern" "extern-fn" "byte" "int" "long" "float" "double"
   "?" "of" "ptr" "ref"
@@ -160,11 +177,14 @@ public defn gen-defs-db (defs-db:String, nm:NameMap, i-all-packages:Seqable<IPac
     val pkg-name = to-string $ name(package)
     add(packages, pkg-name)
     val definitions = to-tuple $ public-definitions(package, nm)
-    for d in definitions do :
-      val n = to-string(name(d))
-      id-defs[n] = cons(info(d), id-defs[n])
-      val pn = string-join $ [pkg-name "/" n]
-      pkg-id-defs[pn] = cons(info(d), pkg-id-defs[pn])
+    for def in definitions do :
+      val name = to-string(name(def))
+      val info = file-info(def)
+      id-defs[name] = cons(info, id-defs[name])
+      val package-name = string-join $ [pkg-name "/" name]
+      match(package:IPackage):
+        pkg-id-defs[package-name] = cons(info, pkg-id-defs[package-name])
+
   val o = FileOutputStream $ defs-db
   val db = DefsDB(stanza-reserved-words, to-tuple $ packages, pkg-id-defs, id-defs)
   serialize(o, db)

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -797,17 +797,23 @@ defn defs-db (parsed:ParseResult) :
       to-tuple(args(parsed)),  ;proj-files
       symbol?("platform"),     ;platform
       symbols?("flags"),       ;flags
-      flag?("optimize"))       ;optimize?    
+      flag?("optimize",),      ;optimize?   
+      flag?("extra")           ;extra? 
+      )        
 
   ;Launch!
   main()
   
 public val DEFS-DB-COMMAND =
-  Command("definitions-database", [
-    SingleFlag("o", false),
-    SingleFlag("platform", true),
-    MultipleFlag("flags", true),
-    MarkerFlag("optimize")], defs-db)
+  Command("definitions-database",
+    [
+      SingleFlag("o", false),
+      SingleFlag("platform", true),
+      MultipleFlag("flags", true),
+      MarkerFlag("optimize"), 
+      MarkerFlag("extra")
+    ], defs-db), 
+    
 
 ;============================================================
 ;================== Check Docs Command ======================

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -798,7 +798,6 @@ defn defs-db (parsed:ParseResult) :
       symbol?("platform"),     ;platform
       symbols?("flags"),       ;flags
       flag?("optimize",),      ;optimize?   
-      flag?("extra")           ;extra? 
       )        
 
   ;Launch!
@@ -811,7 +810,6 @@ public val DEFS-DB-COMMAND =
       SingleFlag("platform", true),
       MultipleFlag("flags", true),
       MarkerFlag("optimize"), 
-      MarkerFlag("extra")
     ], defs-db), 
     
 

--- a/tests/testdb2.stanza
+++ b/tests/testdb2.stanza
@@ -1,0 +1,37 @@
+defpackage test-db :
+  import core
+  import collections
+  import stz/defs-db
+  import stz/defs-db-serializer
+
+let :
+  val filename = command-line-arguments()[1]
+  val db = read-definitions-database $ FileInputStream $ filename 
+  defn print-list (name:String, list:Collection) :
+    println("===== %_ =====" % [name])
+    within indented() :
+      do(println, list)
+  print-list("Reserved Words", reserved-words $ db)
+  val defs = definitions(db) ; HashTable<String, List<IDefinitionsRecord>>
+  defn items-of (src-kind:SrcDefinitionKind): 
+    to-hashtable<String, Tuple<FileInfo>> $ 
+      for kv in defs seq? : 
+        val defs = 
+          to-tuple $ 
+            seq(file-info, filter({kind(_) == src-kind}, value(kv)))
+        if empty?(defs) : 
+          None()
+        else : One $
+          to-string(key(kv)) => defs 
+        
+  val possible-kinds = [
+    SrcDefUnknown, 
+    SrcDefMulti, 
+    SrcDefMethod, 
+    SrcDefFunction, 
+    SrcDefType, 
+    SrcDefPackage,
+    SrcDefVariable,
+  ]
+  for kind in  possible-kinds do : 
+    print-list(to-string $ "%_" % [kind], items-of(kind))


### PR DESCRIPTION
A new definitions database structure is added (DefinitionsDatabase) with serializer/deserializer

The database contains a `HashTable<String, List<Definition>>` where each definition is a structure of the form 

```
public defstruct Definition : 
  name:      String,             ; the name of the definition/corresponding identifier 
  file-info: FileInfo            ; file location 
  kind:      SrcDefinitionKind   ; Used to identify the definition as a type, multi, method, method, function, package, or variable
  source:    SrcDefinitionSource ; Used to identify the origin of the definition (currently, `IPackage|IPkg`)
```

Additionally, several missing keywords were added to the `reserved-words` tuple. 

