### PR TITLE
Exit on non-zero exit code in `call-system` and `Process`

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -7345,7 +7345,7 @@ defn SystemCallException (msg:String) :
     next(args-seq) ;Remove first one
     val cmd = escape-shell-command(cat([file], args-seq))
     val r = call-system(cmd)
-    throw(SystemCallException(linux-error-msg())) when r < 0
+    throw(SystemCallException(linux-error-msg())) when r != 0
     r
 
   public defn initialize-process-launcher () :
@@ -7377,7 +7377,7 @@ defn SystemCallException (msg:String) :
       argvs[i] = addr!(args.items[i].chars)
     val launch_succ = call-c clib/launch_process(addr!(filename.chars), argvs,
       input_v, output_v, error_v, proc.pipeid, addr!([proc]))
-    if launch_succ < 0 :
+    if launch_succ != 0 :
       throw(SystemCallException(linux-error-msg()))
     return proc
   public defn Process (filename:String, args:Seqable<String>) :


### PR DESCRIPTION
The default shell on systems will sometimes case -1 to an 8 bit unsigned integer resulting in a non-zero (but positive) error code, and call-system/Process will report success and not throw a SystemCallException. This PR modifies `core.stanza` to treat non-zero exit codes as errors instead. 