### PR TITLE
Add associated package information with each definition when serializing a DefinitionsDatabase

### DIFF
--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -4,6 +4,10 @@ defpackage stz/defs-db-serializer :
   import collections
   import stz/serializer
 
+;===============================================================================
+; =============================== Types ========================================
+;===============================================================================
+doc: "Represents the kind of item associated with a definition"
 public defenum SrcDefinitionKind : 
   SrcDefUnknown
   SrcDefMulti 
@@ -12,27 +16,34 @@ public defenum SrcDefinitionKind :
   SrcDefVariable
   SrcDefType
   SrcDefPackage
-  
+
+doc: "Represents whether the definition was found in a source file or pkg"
 public public defenum SrcDefinitionSource : 
   PkgDefinition 
   SrcDefinition
 
+doc: "A single defined item"
 public defstruct Definition : 
   name:      Symbol,
   file-info: FileInfo 
   kind:      SrcDefinitionKind 
   source:    SrcDefinitionSource
+  pkg-name:  Symbol,
 
+doc: "A collection of definitions and reserved words in a stanza project"
 public defstruct DefinitionsDatabase: 
   reserved-words: Tuple<String>, 
   definitions: HashTable<Symbol, List<Definition>>
 
+;===============================================================================
+; =========================== Serializers =====================================
+;===============================================================================
 public defserializer (out:OutputStream, in:InputStream) : 
   defunion definitions-database (DefinitionsDatabase) :
     DefinitionsDatabase : (reserved-words:tuple(string), definitions:table)
 
   defunion definition (Definition) : 
-    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src)
+    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src, pkg-name:symbol)
   
   defunion fileinfo (FileInfo) :
     FileInfo : (filename:string, line:int, column:int)
@@ -121,17 +132,6 @@ public defserializer (out:OutputStream, in:InputStream) :
 public defn read-definitions-database (in:InputStream) -> DefinitionsDatabase : 
   deserialize-definitions-database(in) as DefinitionsDatabase
 
-defmethod print (o:OutputStream, kind:SrcDefinitionKind):
-  print{o, _} $ 
-    match(kind):
-      (_:SrcDefUnknown):  "unknown", 
-      (_:SrcDefMulti):    "multi", 
-      (_:SrcDefMethod):   "method", 
-      (_:SrcDefFunction): "function", 
-      (_:SrcDefVariable): "variable", 
-      (_:SrcDefType):     "type", 
-      (_:SrcDefPackage):  "package",
-
 defn to-var-int (x:Int, Y: Byte -> False) :
   defn B0 (x:Int) : Y(to-byte(x))
   defn B1 (x:Int) : Y(to-byte(x >> 8))
@@ -167,3 +167,32 @@ defn from-var-int (N: () -> Byte) -> Int :
     251Y : B0() + 506
     250Y : B0() + 250
     else : to-int(x)
+
+;===============================================================================
+; ============================= Printers =======================================
+;===============================================================================
+defmethod print (o:OutputStream, def:Definition):
+  print(o, "Definition(name:%_,kind:%_,source:%_) in %_ @ %_" % [name(def), kind(def), source(def), pkg-name(def), file-info(def)])
+
+defmethod print (o:OutputStream, ddb:DefinitionsDatabase): 
+  println(o,"Reserved Words:")
+  do(println{IndentedStream(o), _}, reserved-words(ddb))
+  println(o, "Definitions:")
+  do(println{IndentedStream(o), _}, definitions(ddb))
+
+defmethod print (o:OutputStream, kind:SrcDefinitionKind):
+  print{o, _} $ 
+    match(kind):
+      (_:SrcDefUnknown):  "unknown", 
+      (_:SrcDefMulti):    "multi", 
+      (_:SrcDefMethod):   "method", 
+      (_:SrcDefFunction): "function", 
+      (_:SrcDefVariable): "variable", 
+      (_:SrcDefType):     "type", 
+      (_:SrcDefPackage):  "package",
+
+defmethod print (o:OutputStream, src:SrcDefinitionSource):
+  print{o, _} $
+    match(src):
+      (_:SrcDefinition): ".stanza"
+      (_:PkgDefinition): ".pkg|.fpkg"

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -86,9 +86,6 @@ public defmethod kindof (e:IDefn|ILSDefn):
 public defmethod kindof (e:IDefType|ILSDefType): 
   SrcDefType
 
-; public defmethod kindof (e:IPackage|Pkg): 
-;   SrcDefPackage
-
 defstruct DefRec :
   name: Symbol
   info: FileInfo
@@ -128,11 +125,11 @@ defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> 
       loop(e)
   generate<Definition> :
     for exp in exps do :
-      defn add-def (name:IExp, info:False|FileInfo) :
+      defn add-def (e-name:IExp, info:False|FileInfo) :
         match(info:FileInfo) :
-          match(lookup(nm, name)) :
-            (name:Symbol) : 
-              yield $ Definition(name, info, kindof(exp), SrcDefinition)
+          match(lookup(nm, e-name)) :
+            (e-name:Symbol) : 
+              yield $ Definition(e-name, info, kindof(exp), SrcDefinition, name(ipackage))
             (o) : false
       match(exp) :
         (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti) :
@@ -148,7 +145,7 @@ defn collect-public-definitions (packageio:PackageIO) -> Seq<Definition> :
   generate<Definition> :
     defn add-def (name:Symbol, info:False|FileInfo) :
       match(info:FileInfo) : 
-        yield $ Definition(name, info, SrcDefUnknown, PkgDefinition)
+        yield $ Definition(name, info, SrcDefUnknown, PkgDefinition, package(packageio))
 
     for e in exports(packageio) do :
       if visibility(e) is Public :


### PR DESCRIPTION
This PR adds a field to each `Definition` in order to support queries against packages. This is useful when auto-completing against symbols by fully qualified names. 