### PR TITLE
Add writer to defstruct macros

### DIFF
--- a/compiler/stz-core-macros.stanza
+++ b/compiler/stz-core-macros.stanza
@@ -237,11 +237,12 @@ defn StructField (name:Token|Symbol,              ;Name of field
       `init-value => init-value]
 
 defn gen-defstruct (sname:Token|Symbol,
-                    targs:List
-                    parent:Maybe
+                    targs:List,
+                    parent:Maybe,
                     fields:List<StructField>,
-                    constructor:Maybe
-                    printer?:True|False) :
+                    constructor:Maybe,
+                    printer?:True|False,
+                    writer?:True|False) :
   ;===== Bindings =====
   val field-bindings = map(bindings{_, sname}, fields)
 
@@ -323,6 +324,19 @@ defn gen-defstruct (sname:Token|Symbol,
                 }
               ]            
               print(o, "%~(%,)" % [`Struct, print-items])
+          }{}
+          writer?{
+            defmethod write (o:OutputStream, this) :
+              val write-items = [
+                fields{
+                  voidable?{
+                    "%~" % [local-name]
+                  }{
+                    "%~" % [local-name]
+                  }
+                }
+              ]
+              print(o, "%~(%,)" % [`Struct, write-items])
           }{}
           
       ;Sub constructors
@@ -423,6 +437,19 @@ defn gen-defstruct (sname:Token|Symbol,
               ]            
               print(o, "%~(%,)" % [`Struct, print-items])
           }{}
+          writer?{
+            defmethod write (o:OutputStream, this) :
+              val write-items = [
+                fields{
+                  voidable?{
+                    "%~" % [local-name]
+                  }{
+                    "%~" % [local-name]
+                  }
+                }
+              ]
+              print(o, "%~(%,)" % [`Struct, write-items])
+          }{}
     }
 
     ;Multi declarations
@@ -457,7 +484,9 @@ defn gen-defstruct (sname:Token|Symbol,
     `print => `core/print
     `o => gensym(`o)
     `printer? => choice(printer?)
-    `print-items => gensym(`print-items)])
+    `print-items => gensym(`print-items)
+    `writer? => choice(writer?)
+    `write-items => gensym(`write-items)])
 
   ; println(filled)
 
@@ -1567,15 +1596,15 @@ defsyntax core :
 
    defrule id != (defpackage)
 
-
    ;                      DefStruct
    ;                      =========
    defrule exp4 = (defstruct ?name:#id! ?targs:#struct-targs ?parent:#struct-parent
                    ?fields:#struct-fields ?options:#struct-options) :
      val constructor = lookup?(options, `constructor, None())
      val printer = unwrap-token(value?(lookup?(options, `printer, None())))
+     val writer = unwrap-token(value?(lookup?(options, `writer, None())))
      parse-syntax[core / #exp](
-       gen-defstruct(name, targs, parent, fields, constructor, printer))
+       gen-defstruct(name, targs, parent, fields, constructor, printer, writer))
 
    defproduction struct-targs:List
    defrule struct-targs = ((@of ?xs:#id! ...)) : xs
@@ -1596,6 +1625,7 @@ defsyntax core :
    defproduction struct-option!:KeyValue<Symbol,?>
    defrule struct-option! = (constructor => ?name:#id!) : `constructor => One(name)
    defrule struct-option! = (printer => ?v:#bool!) : `printer => One(v)
+   defrule struct-option! = (writer => ?v:#bool!) : `writer => One(v)
    fail-if struct-option! = () : CSE(closest-info(), "Expected struct option declaration here.")
 
    defproduction struct-field!:StructField


### PR DESCRIPTION
New behaviour building with `stanza compiler/stz-core-macros.stanza stz/driver -o my-stanza`:
```
lbstanza$ cat test-writer.stanza
defstruct Q :
  x:Float
  y:Float
with: (writer => true)

val q = Q(124.12341f, 643.968989f)
println(q)
println("%~" % [q])
```

```
lbstanza$ ./my-stanza run test-writer.stanza 
[Q object]
Q(124.123f, 643.969f)
```

___________

```
lbstanza$ cat test.stanza 
defstruct Q :
  x:Float
  y:Float
with: (printer => true)

val q = Q(124.12341f, 643.968989f)
println(q)
println("%~" % [q])
```

```
lbstanza$ ./my-stanza run test.stanza 
Q(x = 124.123f, y = 643.969f)
Q(x = 124.123f, y = 643.969f)
```
