### PR TITLE
[WIP] Add basic write helpers as well as printer/writer for each type in collections

### DIFF
--- a/core/collections.stanza
+++ b/core/collections.stanza
@@ -37,6 +37,15 @@ defstruct SetItem<K> :
 defmethod print (o:OutputStream, x:SetItem) :
   print(o, "(%_) %_" % [hash(x), key(x)])
 
+defn indented-list (items: Seqable) :
+  new Printable :
+    defmethod print (o:OutputStream, this) :
+      val o2 = IndentedStream(o)
+      do(lnprint{o2, _}, items)
+    defmethod write (o:OutputStream, this) :
+      val o2 = IndentedStream(o)
+      do(lnwrite{o2, _}, items)
+
 ;Binary search
 ;Returns n such that the first n numbers in xs < v
 defn bsearch<?T,?S> (less?: (T, S) -> True|False,
@@ -229,11 +238,23 @@ public defn to-vector<T> (xs:Seqable<T>) -> Vector<T> :
    add-all(v, xs)
    v
 
+public defn to-vector<?T> (xs:Seqable<?T>) -> Vector<T> :
+  to-vector<T>(xs)
+
 public defn map<R,?T> (f: T -> R, v:Vector<?T>) -> Vector<R> :
    val ret = Vector<R>(length(v))
    add-all(ret, seq(f, v))
    ret
 
+;==================================
+;======== Printer / Writer ========
+;==================================
+
+public defmethod print (o: OutputStream, v: Vector) :
+  print(o, "Vector(%*)" % [v])
+
+public defmethod write (o: OutputStream, v: Vector) :
+  print(o, "to-vector([%@])" % [v])
 
 ;============================================================
 ;====================== Queues ==============================
@@ -272,6 +293,7 @@ public defn Queue<T> (initial-cap:Int) -> Queue<T> :
       (begin + i) & (cap - 1)
 
    new Queue<T> :
+      ; Iteration over a queue is tail to head (Last in First iterated upon) instead of the conventional head to tail
       defmethod get (this, i:Int) :
          core/ensure-index-in-bounds(this, i)
          array[wrapped-index(i)]
@@ -308,6 +330,25 @@ public defn Queue<T> (initial-cap:Int) -> Queue<T> :
 
 public defn Queue<T> () -> Queue<T> :
    Queue<T>(8)
+
+public defn to-queue<T> (xs:Seqable<T>) -> Queue<T> :
+   val q = Queue<T>()
+   do(add{q, _}, xs)
+   q
+
+public defn to-queue<?T> (xs:Seqable<?T>) -> Queue<T> :
+  to-queue<T>(xs)
+
+;==================================
+;======== Printer / Writer ========
+;==================================
+
+public defmethod print (o: OutputStream, q: Queue) :
+  print(o, "Queue(%_)" % [string-join(in-reverse(q), " < ")])
+
+public defmethod write (o: OutputStream, q: Queue) :
+  print(o, "to-queue([%@])" % [in-reverse(q)q])
+
 
 ;============================================================
 ;======================== Tables ============================
@@ -797,10 +838,26 @@ public defn to-hashtable<K,V> (es:Seqable<KeyValue<K,V>>) -> HashTable<K,V> :
     t[key(e)] = value(e)
   t
 
+public defn to-hashtable<?K,?V> (es:Seqable<KeyValue<?K,?V>>) -> HashTable<K,V> :
+  to-hashtable<K,V>(es)
+
 public defn to-hashtable<K,V> (ks:Seqable<K>, vs:Seqable<V>) -> HashTable<K,V> :
   val t = HashTable<K,V>()
   set-all(t, ks, vs)
   t
+
+public defn to-hashtable<?K,?V> (ks:Seqable<?K>, vs:Seqable<?V>) -> HashTable<K,V> :
+  to-hashtable<K,V>(ks, vs)
+
+;==================================
+;======== Printer / Writer ========
+;==================================
+
+public defmethod print (o: OutputStream, t: HashTable) :
+  print(o, "HashTable(%_)" % [indented-list(t)])
+
+public defmethod write (o: OutputStream, t: HashTable) :
+  print(o, "to-hashtable([%~])" % [indented-list(t)])
 
 ;============================================================
 ;===================== Int Tables ===========================
@@ -1179,10 +1236,26 @@ public defn to-inttable<V> (es:Seqable<KeyValue<Int,V>>) -> IntTable<V> :
     t[key(e)] = value(e)
   t
 
+public defn to-inttable<?V> (es:Seqable<KeyValue<Int,?V>>) -> IntTable<V> :
+  to-inttable<V>(es)
+
 public defn to-inttable<V> (ks:Seqable<Int>, vs:Seqable<V>) -> IntTable<V> :
   val t = IntTable<V>()
   set-all(t, ks, vs)
   t
+
+public defn to-inttable<?V> (ks:Seqable<Int>, vs:Seqable<?V>) -> IntTable<V> :
+  to-inttable<V>(ks, vs)
+
+;==================================
+;======== Printer / Writer ========
+;==================================
+
+public defmethod print (o: OutputStream, t: IntTable) :
+  print(o, "IntTable(%_)" % [indented-list(t)])
+
+public defmethod write (o: OutputStream, t: IntTable) :
+  print(o, "to-inttable([%~])" % [indented-list(t)])
 
 ;============================================================
 ;======================== Sets ==============================
@@ -1460,6 +1533,16 @@ public defn hashset-intersection<T> (a:Seqable<T&Equalable&Hashable>, b:Seqable<
   val aset = to-hashset<T>(a)
   to-hashset<T> $ filter({aset[_]}, b)
 
+;==================================
+;======== Printer / Writer ========
+;==================================
+
+public defmethod print (o: OutputStream, s: HashSet) :
+  print(o, "HashSet(%*)" % [s])
+
+public defmethod write (o: OutputStream, s: HashSet) :
+  print(o, "to-hashset([%@])" % [s])
+
 ;============================================================
 ;====================== IntSets =============================
 ;============================================================
@@ -1686,3 +1769,13 @@ public defn to-intset (xs:Seqable<Int>) -> IntSet :
   val s = IntSet()
   do(add{s, _}, xs)
   s
+
+;==================================
+;======== Printer / Writer ========
+;==================================
+
+public defmethod print (o: OutputStream, s: IntSet) :
+  print(o, "IntSet(%*)" % [s])
+
+public defmethod write (o: OutputStream, s: IntSet) :
+  print(o, "to-intset([%@])" % [s])

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3156,6 +3156,7 @@ public defn print-all (xs:Seqable) :
 public defn println-all (xs:Seqable) :
    println-all(CURRENT-OUTPUT-STREAM, xs)
 
+
 ;============================================================
 ;=================== Input Streams ==========================
 ;============================================================
@@ -7916,6 +7917,42 @@ public defn write-all (o:OutputStream, xs:Seqable) -> False :
    while not empty?(xs-seq) :
       print(o, " ")
       write(o, next(xs-seq))
+
+;                 Convenience Functions
+;                 =====================
+
+
+public defn writeln (o:OutputStream, x) :
+  write(o, x)
+  print(o, NL)
+
+public defn lnwrite (o:OutputStream, x) :
+  print(o, NL)
+  write(o, x)
+
+public defn writeln-all (o:OutputStream, xs:Seqable) :
+   write-all(o, xs)
+   print(o, NL)
+
+
+;              Write to Current Output Stream
+;              ==============================
+
+public defn write (x) :
+   write(CURRENT-OUTPUT-STREAM, x)
+
+public defn write-all (xs:Seqable) :
+   write-all(CURRENT-OUTPUT-STREAM, xs)
+
+public defn writeln (x) :
+   writeln(CURRENT-OUTPUT-STREAM, x)
+
+public defn lnwrite (x) :
+   lnwrite(CURRENT-OUTPUT-STREAM, x)
+
+public defn writeln-all (xs:Seqable) :
+   writeln-all(CURRENT-OUTPUT-STREAM, xs)
+
 
 ;                    Escape Sequences
 ;                    ================

--- a/tests/test-collections-printers.stanza
+++ b/tests/test-collections-printers.stanza
@@ -1,0 +1,24 @@
+#use-added-syntax(tests)
+defpackage test-collections-printers :
+  import core
+  import collections
+
+
+deftest test-hashtable :
+  val h       =  to-hashtable([1 => "a" 2 => "b"])
+  val h-write = trim $ \<S>
+to-hashtable([
+  1 => "a"
+  2 => "b"])
+<S>
+  val h-print = trim $ \<S>
+HashTable(
+  1 => "a"
+  2 => "b")
+<S>
+
+  #ASSERT(to-string("%~" % [h]) == h-write)
+  #ASSERT(to-string(h) == h-print)
+
+; TODO: inttable, hashset, intset, vector, queue, big nested example of the previous elements
+; TODO: basic writeln, lnwrite... calls


### PR DESCRIPTION
This PR enforces:
- `print` gives human readable output,
- `write` gives machine readable output.

It contains:
- basic write helpers
- printer / writer for each type in collections

3 things missing:
- need to talk with @CuppoJava if he is okay with this.
I think that this should be in collections as anybody that handles an hashtable should have its printer available and not risk to have forgotten to import another package and have to stop the program and add the import to display some variable content in your program.
- show other people the proposed `print` outputs for types in collections, if somebody has a better proposition
- I need to finish the test file (see TODO in it). But I get a Stack Overflow for no apparent reason:
```
lbstanza$ stanza run-test core/core.stanza tests/test-collections-printers.stanza 
FATAL ERROR: Stack overflow
Segmentation fault (core dumped)
```
even when commenting out all changes in core/core.stanza

2 remarks that would require breaking changes to change:
- queue iteration order: https://github.com/StanzaOrg/lbstanza/issues/82
- print is human readable (no theoretical constraint, could be anything, it is supposed to look good) while write is machine readable (there is a hard constraint: getting a valid stanza expression that evaluates to the same object without having to import any other package than the package containing the definition of the type and the package where the writer is defined is different). So a printer is not a writer but a writer could be a printer. That is why `write` calling `print` by default is wrong. On the contrary, `print` could call `write` by default.