### PR TITLE
Implementation of resizable heap by mmap/mprotect

### DIFF
--- a/compiler/stz-vm.stanza
+++ b/compiler/stz-vm.stanza
@@ -364,12 +364,12 @@ public defn VirtualMachine () :
       VirtualMachine(X64Backend())
 
 public lostanza defn VirtualMachine (backend:ref<Backend>) -> ref<VirtualMachine> :
-  val heap-size = 4 * 1024
+  val heap-size = round-up-to-whole-pages(4 * 1024)
   val vmstate:ptr<VMState> = call-c clib/stz_malloc(sizeof(VMState))
   vmstate.registers = call-c clib/stz_malloc(8 * 256)
-  vmstate.heap = call-c clib/stz_malloc(heap-size)
+  vmstate.heap = call-c clib/stz_memory_map(heap-size, MAXIMUM-HEAP-SIZE)
   vmstate.heap-limit = vmstate.heap + heap-size
-  vmstate.free = call-c clib/stz_malloc(heap-size)
+  vmstate.free = call-c clib/stz_memory_map(heap-size, MAXIMUM-HEAP-SIZE)
   vmstate.free-limit = vmstate.free + heap-size
   vmstate.heap-top = vmstate.heap
   vmstate.current-stack = alloc-stack(vmstate)

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -56,6 +56,11 @@ protected extern file_time_modified: ptr<byte> -> long
 protected extern execvp: (ptr<byte>, ptr<ptr<byte>>) -> int
 protected extern execv: (ptr<byte>, ptr<ptr<byte>>) -> int
 
+;Memory mapping
+protected extern stz_memory_map: (long, long) -> ptr<?>
+protected extern stz_memory_unmap: (ptr<?>, long) -> int
+protected extern stz_memory_resize: (ptr<?>, long, long) -> int
+
 ;Process libraries
 protected extern launch_process: (ptr<byte>, ptr<ptr<byte>>, int, int, int, int, ptr<?>) -> int
 protected extern delete_process_pipes: (ptr<?>, ptr<?>, ptr<?>, int) -> int
@@ -597,7 +602,11 @@ lostanza defn read-const-chars (len:long) -> ptr<byte> :
 ;============================================================
 
 lostanza var initialized-gc-notifiers? : long = 0L
-lostanza var MAXIMUM-HEAP-SIZE : long = 4L * 1024L * 1024L * 1024L
+public lostanza var MAXIMUM-HEAP-SIZE : long = 4L * 1024L * 1024L * 1024L
+lostanza val SYSTEM-PAGE-SIZE : long = 4096
+
+public lostanza defn round-up-to-whole-pages (x:long) -> long :
+  return (x + (SYSTEM-PAGE-SIZE - 1)) & ( ~ (SYSTEM-PAGE-SIZE - 1));
 
 lostanza defn extend-heap (size:long) -> long :
   ;Collect garbage, and ensure we freed enough space
@@ -979,10 +988,11 @@ lostanza defn collect-garbage (size:long) -> long :
       while space < desired-space : space = space * 2
       space = min(space, MAXIMUM-HEAP-SIZE)
 
-      ;Resize the heap and use the GC to move contents over
-      resize-freespace(vms, space)
-      collect-garbage(vms)
-      resize-freespace(vms, space)
+      ;Resize the heap and freespace
+      call-c clib/stz_memory_resize(vms.heap, vms.heap-limit - vms.heap, space)
+      vms.heap-limit = vms.heap + space
+      call-c clib/stz_memory_resize(vms.free, vms.free-limit - vms.free, space)
+      vms.free-limit = vms.free + space
 
   ;We're not out of space, so we don't need to expand the heap,
   ;but we might want to for next time.
@@ -1001,16 +1011,11 @@ lostanza defn collect-garbage (size:long) -> long :
 
     ;Resize free if necessary
     if new-space > free-space :
-      resize-freespace(vms, new-space)
+      call-c clib/stz_memory_resize(vms.free, vms.free-limit - vms.free, new-space)
+      vms.free-limit = vms.free + new-space
 
   ;Return the new space remaining
   return vms.heap-limit - vms.heap
-
-lostanza defn resize-freespace (vms:ptr<VMState>, space:long) -> int :
-  call-c clib/stz_free(vms.free)
-  vms.free = call-c clib/stz_malloc(space)
-  vms.free-limit = vms.free + space
-  return 0
 
 ;============================================================
 ;==================== Garbage Collector =====================
@@ -2410,9 +2415,10 @@ defn ensure-valid-max-heap-size (sz:Long) :
   if sz < cur-sz :
     fatal("Cannot set heap size to %_ bytes which is smaller than the current heap size (%_ bytes)." % [
       sz, cur-sz])
+
 public lostanza defn set-max-heap-size (sz:ref<Long>) -> ref<False> :
   ensure-valid-max-heap-size(sz)
-  MAXIMUM-HEAP-SIZE = sz.value
+  MAXIMUM-HEAP-SIZE = round-up-to-whole-pages(sz.value)
   return false
 
 ;============================================================

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -69,56 +69,6 @@ int input_argc;
 char** input_argv;
 int input_argv_needs_free;
 
-//     Main Driver
-//     ===========
-void* alloc (VMInit* init, long type, long size){
-  void* ptr = init->heap_top + 8;
-  *(long*)(init->heap_top) = type;
-  init->heap_top += 8 + size;
-  return ptr;  
-}
-
-uint64_t alloc_stack (VMInit* init){
-  Stack* stack = alloc(init, STACK_TYPE, sizeof(Stack));
-  int initial_stack_size = 4 * 1024;
-  long size = initial_stack_size + sizeof(StackFrameHeader);
-  StackFrameHeader* frameheader = (StackFrameHeader*)stz_malloc(size);
-  frameheader->pool_index = -1;
-  frameheader->mark = 0;
-  stack->size = initial_stack_size;
-  stack->frames = frameheader->frames;
-  stack->stack_pointer = NULL;
-  return (uint64_t)stack - 8 + 1;  
-}
-
-int main (int argc, char* argv[]) {
-  #if defined(FMALLOC)
-    init_fmalloc();
-  #endif
-  
-  input_argc = argc;
-  input_argv = argv;
-  input_argv_needs_free = 0;
-  VMInit init;
-
-  //Allocate heap and free
-  int initial_heap_size = 1024 * 1024;
-  init.heap = (char*)stz_malloc(initial_heap_size);
-  init.heap_limit = init.heap + initial_heap_size;
-  init.heap_top = init.heap;
-  init.free = (char*)stz_malloc(initial_heap_size);
-  init.free_limit = init.free + initial_heap_size;
-
-  //Allocate stacks
-  init.current_stack = alloc_stack(&init);
-  init.system_stack = alloc_stack(&init);   
-
-  //Call Stanza entry
-  stanza_entry(&init);
-  
-  return 0;
-}
-
 //     Macro Readers
 //     =============
 FILE* get_stdout () {return stdout;}
@@ -566,6 +516,40 @@ int make_pipe (char* prefix, char* suffix){
   return mkfifo(name, S_IRUSR|S_IWUSR);
 }
 
+//============================================================
+//================== Stanza Memory Mapping ===================
+//============================================================
+
+static void protect(void* p, long size, int prot) {
+  if (size && mprotect(p, size, prot)) exit_with_error();
+}
+
+void* stz_memory_map (long min_size, long max_size) {
+  void* p = mmap(NULL, max_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (p == MAP_FAILED) exit_with_error();
+
+  protect(p, min_size, PROT_READ | PROT_WRITE | PROT_EXEC);
+  return p;
+}
+
+void stz_memory_unmap (void* p, long size) {
+  if (p && munmap(p, size)) exit_with_error();
+}
+
+void stz_memory_resize (void* p, long old_size, long new_size) {
+  long min_size = old_size;
+  long max_size = new_size;
+  int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+
+  if (min_size > max_size) {
+    min_size = new_size;
+    max_size = old_size;
+    prot = PROT_NONE;
+  }
+
+  protect((char*)p + min_size, max_size - min_size, prot);
+}
+
 //------------------------------------------------------------
 //----------------------- Serialization ----------------------
 //------------------------------------------------------------
@@ -967,3 +951,56 @@ void retrieve_process_state (long pid, ProcessState* s, int wait_for_termination
 //============================================================
 //============== End Process Runtime =========================
 //============================================================
+
+//     Main Driver
+//     ===========
+void* alloc (VMInit* init, long type, long size){
+  void* ptr = init->heap_top + 8;
+  *(long*)(init->heap_top) = type;
+  init->heap_top += 8 + size;
+  return ptr;
+}
+
+uint64_t alloc_stack (VMInit* init){
+  Stack* stack = alloc(init, STACK_TYPE, sizeof(Stack));
+  int initial_stack_size = 4 * 1024;
+  long size = initial_stack_size + sizeof(StackFrameHeader);
+  StackFrameHeader* frameheader = (StackFrameHeader*)stz_malloc(size);
+  frameheader->pool_index = -1;
+  frameheader->mark = 0;
+  stack->size = initial_stack_size;
+  stack->frames = frameheader->frames;
+  stack->stack_pointer = NULL;
+  return (uint64_t)stack - 8 + 1;
+}
+
+int main (int argc, char* argv[]) {
+  #if defined(FMALLOC)
+    init_fmalloc();
+  #endif
+
+  input_argc = argc;
+  input_argv = argv;
+  input_argv_needs_free = 0;
+  VMInit init;
+
+  //Allocate heap and freespace
+  const int initial_heap_size = 1024 * 1024;
+  const long maximum_heap_size = 4L * 1024 * 1024 * 1024;
+
+  init.heap = (char*)stz_memory_map(initial_heap_size, maximum_heap_size);
+  init.heap_limit = init.heap + initial_heap_size;
+  init.heap_top = init.heap;
+  init.free = (char*)stz_memory_map(initial_heap_size, maximum_heap_size);
+  init.free_limit = init.free + initial_heap_size;
+
+  //Allocate stacks
+  init.current_stack = alloc_stack(&init);
+  init.system_stack = alloc_stack(&init);
+
+  //Call Stanza entry
+  stanza_entry(&init);
+
+  //Heap and freespace are disposed by OS at process termination
+  return 0;
+}


### PR DESCRIPTION
Resizable memory regions for heap semispaces  are implemented as `MAXIMUM-HEAP-SIZE` address space ranges reserved with `mmap`. Memory pages within those address ranges are allocated as necessary with `mprotect`. The resizing is performed in-place.

The implementation is tested on a heap saturation stress test. 

This is the first step in implementation of a better garbage collector. 