### PR TITLE
jb/inlining

### DIFF
--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -92,6 +92,8 @@ defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
   defn run-pass (pass-name:String, f:(EPackage, EHier, VarTable) -> EPackage, suffix:String, update-tables?:True|False) :
     run-pass(pass-name, f{_, ehier, global-vt}, suffix, update-tables?)
 
+  val no-inlineables = IntSet()
+
   ;Dump input
   ;dump(cur-package, "logs", "input")
   run-pass("Map Methods", map-methods, "mapped-methods", false)
@@ -107,15 +109,16 @@ defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
   run-pass("Box Mutables", box-mutables, "boxed", false)
   run-pass("Detect Loops", detect-loops, "looped", false)
   run-pass("Simple Inline", simple-inline, "inlined", false)
-  run-pass("Within Package Inline", within-package-inline{_, no-inlineables, { true }, IntSet()}, "wp-inlined", false)
+  run-pass("Within Package Inline", within-package-inline{_, no-inlineables}, "wp-inlined", false)
 
   if optimize? :
     run-pass("Remove Reified Types", force-remove-types, "removed-types", true)
   run-pass("Lambda Lift", lambda-lift, "lambda", true)
   run-pass("Lift Objects", lift-objects, "objlifted", true)
   if optimize? :
+    val inlineables = calc-inlineables(epackage)
     run-pass("Resolve Methods", resolve-methods, "resolved-methods", false)
-    run-pass("Within Package Inline", within-package-inline{_, inlineables, { changed?[_] }, changed?}, "within-package-inlined", false)
+    run-pass("Within Package Inline", within-package-inline{_, inlineables}, "within-package-inlined", false)
   run-pass("Resolve Matches", resolve-matches, "resolved-matches", false)
   run-pass("Lift Closures", lift-closures, "closurelifted", false)
   run-pass("Lift Type Objects", lift-type-objects, "typelifted", false)
@@ -1508,62 +1511,88 @@ defn simple-inline (epackage:EPackage) :
 ;================== Renaming ================================
 ;============================================================
 
-defn within-package-inline (epackage:EPackage) :
+defn inc (t:IntTable<Int>, k:Int) -> Int :
+  update(t, { _ + 1 }, k)
+
+defn num-reads (epackage:EPackage) -> IntTable<Int> :
+  val num-reads = IntTable<Int>(0)
+  defn walk (e:ELItem) :
+    match(e) :
+      (e:EDefn|EDefmethod|EInit) :
+        do(walk, e)
+      (e:EVar) :
+        inc(num-reads, n(e))
+      (e) :
+        do(walk, e)
+  do(walk, exps(epackage))
+  num-reads
+
+defn within-package-inline (epackage:EPackage, inlineables:IntSet) :
+  ;Table for holding inlined functions
+  val inlined-functions = IntTable<ELocalFn|EDefn|EDefmethod>()
+  defn add-to-inline-table (l:ELocalFn|EDefn|EDefmethod) :
+    inlined-functions[n(l)] = l
+  val num-reads = num-reads(epackage)
+
+  ;Determine whether a function should be inlined
+  defn leaf? (body:EBody) -> True|False :
+    not (for i in ins(body) any? : i is ECall|ETCall)
+  defn inline? (n:Int, f:EFunction, top?:True|False) :
+    match(f) :
+      (f:EMultifn) :
+        all?(inline?{n, _, top?}, funcs(f))
+      (f:EFn) :
+        val len = length(ins(body(f)))
+        empty?(localfns(body(f))) and
+          empty?(localobjs(body(f))) and
+          ((not top? and num-reads[n] == 1) or (len < 8 or (leaf?(body(f)) and len < 11)))
+
+  for exp in exps(epackage) do :
+    match(exp:EDefmethod|EDefn) :
+      add-to-inline-table(exp) when (inline?(n(exp), func(exp), true) or inlineables[n(exp)])
+
   defn inline-texp (e:ETExp) :
     ;Inlining a single function
-    ;Table for holding inlined functions
-    val inlined-functions = IntTable<ELocalFn>()
-    defn add-to-inline-table (l:ELocalFn) :
-      inlined-functions[n(l)] = l
-      
     defn get-inlined-function (fid:Int, arity:Int) :
       if key?(inlined-functions, fid) :
         val efns = efns(func(inlined-functions[fid]))
         for f in efns find :
           arity == length(args(f))
 
-    ;Determine whether a function should be inlined
-    defn inline? (f:EFunction) :
-      match(f) :
-        (f:EMultifn) :
-          all?(inline?, funcs(f))
-        (f:EFn) :
-          empty?(localfns(body(f))) and
-          empty?(localobjs(body(f))) and
-          length(ins(body(f))) < 8
-
     defn inline (e:ELBigItem) :
-      match(e:EBody) :
-        ;Add to inline table if appropriate
-        for l in localfns(e) do :
-          add-to-inline-table(l) when inline?(func(l))
-        ;Create buffer
-        val buffer = BodyBuffer(e)
-        for l in localfns(e) do :
-          emit(buffer, inline(l) as ELocalFn)
-        for o in localobjs(e) do :
-          emit(buffer, inline(o) as ELocalObj)
-        for i in ins(e) do :
-          match(i:ECall|ETCall) :
-            val f* = deconstruct-function(f(i))
-            if empty?(f*) :
-              emit(buffer, i)
-            else :
-              val [fid, targs] = value!(f*)
-              match(get-inlined-function(fid, length(ys(i)))) :
-                (func:EFn) :
-                  val [ret, tail?] = match(i) :
-                    (i:ECall) : [x(i), false]
-                    (i:ETCall) : [false, true]
-                  inline-call(buffer, ret, rename-fn(func), targs, ys(i), tail?)
-                (_:False) :
-                  emit(buffer, i)          
-          else :
-            emit(buffer, i)
-        ;Return the body
-        to-body(buffer, true, false, false)
-      else :
-        map(inline, e)        
+      match(e) :
+        (e:EBody) :
+          ;Add to inline table if appropriate
+          for l in localfns(e) do :
+            add-to-inline-table(l) when inline?(n(l), func(l), false)
+          ;Create buffer
+          val buffer = BodyBuffer(e)
+          for l in localfns(e) do :
+            emit(buffer, inline(l) as ELocalFn)
+          for o in localobjs(e) do :
+            emit(buffer, inline(o) as ELocalObj)
+          for i in ins(e) do :
+            match(i) :
+              (i:ECall|ETCall) :
+                val f* = deconstruct-function(f(i))
+                if empty?(f*) :
+                  emit(buffer, i)
+                else :
+                  val [fid, targs] = value!(f*)
+                  match(get-inlined-function(fid, length(ys(i)))) :
+                    (func:EFn) :
+                      val [ret, tail?] = match(i) :
+                        (i:ECall) : [x(i), false]
+                        (i:ETCall) : [false, true]
+                      inline-call(buffer, ret, rename-fn(func), targs, ys(i), tail?)
+                    (_:False) :
+                      emit(buffer, i)          
+              (i) :
+                emit(buffer, i)
+          ;Return the body
+          to-body(buffer, true, false, false)
+        (e) :
+          map(inline, e)        
 
     ;Inline the top level
     inline(e) as ETExp

--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -33,6 +33,35 @@ public defn lower-unoptimized (epackage:EPackage) -> EPackage :
 ;========================= Lowering =========================
 ;============================================================
 
+defn calc-inlineables (epackage:EPackage) -> IntSet :
+  val multi-ids = [ValId(`core, `do)]
+  val defn-ids = [ValId(`collections, `bsearch)] ; ValId(`core, `Range)
+
+  defn match-id? (x:RecId, y:RecId) -> True|False :
+    package(x) == package(y) and name(x) == name(y)
+
+  val inlineable-multis = to-intset $ generate<Int> :
+    for e in exports(packageio(epackage)) do :
+      val rec = rec(e)
+      match(rec:MultiRec) :
+        yield(n(e)) when any?(match-id?{id(rec), _}, multi-ids)
+
+  val inlineable-defns = to-intset $ generate<Int> :
+    for e in exports(packageio(epackage)) do :
+      val rec = rec(e)
+      match(rec:FnRec) :
+        yield(n(e)) when any?(match-id?{id(rec), _}, defn-ids)
+
+  val inlineables = 
+    to-intset $ generate<Int> :
+      for e in exps(epackage) do :
+        match(e) :
+          (e:EDefmethod) : yield(n(e)) when inlineable-multis[multi(e)]
+          (e:EDefn) : yield(n(e)) when inlineable-defns[n(e)]
+          (e) : false
+
+  inlineables
+
 defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
   ;Reset id generation
   take-ids(epackage)
@@ -78,13 +107,15 @@ defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
   run-pass("Box Mutables", box-mutables, "boxed", false)
   run-pass("Detect Loops", detect-loops, "looped", false)
   run-pass("Simple Inline", simple-inline, "inlined", false)
-  run-pass("Within Package Inline", within-package-inline, "wp-inlined", false)
+  run-pass("Within Package Inline", within-package-inline{_, no-inlineables, { true }, IntSet()}, "wp-inlined", false)
+
   if optimize? :
     run-pass("Remove Reified Types", force-remove-types, "removed-types", true)
   run-pass("Lambda Lift", lambda-lift, "lambda", true)
   run-pass("Lift Objects", lift-objects, "objlifted", true)
   if optimize? :
     run-pass("Resolve Methods", resolve-methods, "resolved-methods", false)
+    run-pass("Within Package Inline", within-package-inline{_, inlineables, { changed?[_] }, changed?}, "within-package-inlined", false)
   run-pass("Resolve Matches", resolve-matches, "resolved-matches", false)
   run-pass("Lift Closures", lift-closures, "closurelifted", false)
   run-pass("Lift Type Objects", lift-type-objects, "typelifted", false)

--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -33,6 +33,9 @@ public defn lower-unoptimized (epackage:EPackage) -> EPackage :
 ;========================= Lowering =========================
 ;============================================================
 
+;calculate fns to inline by
+;looking up multis and defns by id where
+;defmethods are inlined if multis are inlined
 defn calc-inlineables (epackage:EPackage) -> IntSet :
   val multi-ids = [ValId(`core, `do)]
   val defn-ids = [ValId(`collections, `bsearch)] ; ValId(`core, `Range)
@@ -1514,6 +1517,7 @@ defn simple-inline (epackage:EPackage) :
 defn inc (t:IntTable<Int>, k:Int) -> Int :
   update(t, { _ + 1 }, k)
 
+;calculate how many times vars are read by others
 defn num-reads (epackage:EPackage) -> IntTable<Int> :
   val num-reads = IntTable<Int>(0)
   defn walk (e:ELItem) :
@@ -1527,6 +1531,8 @@ defn num-reads (epackage:EPackage) -> IntTable<Int> :
   do(walk, exps(epackage))
   num-reads
 
+;inline within package function calls using size rules and
+;allow a passed in set of inlineables to always be inlined
 defn within-package-inline (epackage:EPackage, inlineables:IntSet) :
   ;Table for holding inlined functions
   val inlined-functions = IntTable<ELocalFn|EDefn|EDefmethod>()
@@ -1534,9 +1540,10 @@ defn within-package-inline (epackage:EPackage, inlineables:IntSet) :
     inlined-functions[n(l)] = l
   val num-reads = num-reads(epackage)
 
-  ;Determine whether a function should be inlined
+  ;leaf is a body with no fn calls in it
   defn leaf? (body:EBody) -> True|False :
     not (for i in ins(body) any? : i is ECall|ETCall)
+  ;Determine whether a function should be inlined
   defn inline? (n:Int, f:EFunction, top?:True|False) :
     match(f) :
       (f:EMultifn) :
@@ -1545,7 +1552,9 @@ defn within-package-inline (epackage:EPackage, inlineables:IntSet) :
         val len = length(ins(body(f)))
         empty?(localfns(body(f))) and
           empty?(localobjs(body(f))) and
-          ((not top? and num-reads[n] == 1) or (len < 8 or (leaf?(body(f)) and len < 11)))
+          ((not top? and num-reads[n] == 1) or ; local single read functions
+           len < 8 or                          ; small functions
+           (leaf?(body(f)) and len < 11))      ; hand tuned to inline juicy leaf functions
 
   for exp in exps(epackage) do :
     match(exp:EDefmethod|EDefn) :


### PR DESCRIPTION
Adjust within-package-inlining to do more inlining of profitable to inline function calls.  Inline local single-use function calls, slightly bigger leaf functions, and determined to be profitable functions.  Also, do inlining once more after method resolution so that more method calls can be inlined.