### PR TITLE
Build script improvements for cross-compilation

### DIFF
--- a/scripts/wfinish.sh
+++ b/scripts/wfinish.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z "$CC" ]]; then
+    if [[ "$(uname -s)" == MINGW* ]]; then
+        # Not cross-compiling, so just use the stock GCC
+        CC=gcc
+    else
+        echo 'Need to set $CC to a valid compiler or cross-compiler' >/dev/stderr
+        exit 2
+    fi
+fi
+
+CCFLAGS="-DPLATFORM_WINDOWS -std=gnu99 -O3 -fPIC -Wall $CCFLAGS"
+
+[[ ! -d "build" ]] && mkdir "build"
+
+"$CC" $CCFLAGS -c core/sha256.c       -o build/sha256.o
+"$CC" $CCFLAGS -c compiler/cvm.c      -o build/cvm.o
+"$CC" $CCFLAGS -c runtime/linenoise.c -o build/linenoise.o
+"$CC" $CCFLAGS -c runtime/driver.c    -o build/driver.o
+
+"$CC" \
+    build/sha256.o    \
+    build/cvm.o       \
+    build/linenoise.o \
+    build/driver.o    \
+    wstanza.s         \
+    -o wstanza -lm -lpthread -fPIC


### PR DESCRIPTION
This patch improves the existing build script (`scripts/make.sh`) to make cross-compilation easier. It also streamlines some aspects of the current build process.

The main change is the addition of a `<platform>` parameter to `scripts/make.sh`. This can be one of `windows`, `linux`, or `os-x`, corresponding (I think) to the values accepted by the Stanza compiler with `-platform`. If one is not passed, the script errors out (could detect current platform in the future?)

Additionally, this patch makes it so we only build the platform requested (previously would always build OS-X and Linux). It also adds a finish script for Windows (since one did not previously exist).