### PR TITLE
Introduce `stz_*` types in Stanza runtime

### DIFF
--- a/runtime/types.h
+++ b/runtime/types.h
@@ -1,0 +1,23 @@
+#ifndef RUNTIME_TYPES_H
+#define RUNTIME_TYPES_H
+#include <stdint.h>
+
+// These types match the size/signedness of the corresponding Stanza type,
+// whereas the size/signedness of the corresponding bare C type (e.g. `char`,
+// `int`) may be platform-specific. We use these at the interface between
+// Stanza and the runtime to prevent size/signedness mismatch.
+typedef int64_t stz_long;
+typedef int32_t stz_int;
+typedef uint8_t stz_byte;
+typedef double  stz_double;
+typedef float   stz_float;
+
+// Conversion macros between Stanza-strings (stz_byte*) and C-strings (char*)
+// These are necessary because `char` may be signed, but `stz_byte` is unsigned
+// It also helps us identify exactly where conversions are occurring
+#define C_STR(x)    ((char*)(x))
+#define C_CSTR(x)   ((const char*)(x))
+#define STZ_STR(x)  ((stz_byte*)(x))
+#define STZ_CSTR(x) ((const stz_byte*)(x))
+
+#endif


### PR DESCRIPTION
In the Stanza runtime, we have a bunch of C code that is called from Stanza. In doing so, it is important that we make sure that the size/signedness of types in Stanza is preserved when passed over the boundary to C. This is especially necessary because, while types in Stanza may often have the same name as types in C, their representation can be very different.

One place where our usage of C types caused issue was `void* stz_malloc(long)`, which has the corresponding Stanza definition `extern stz_malloc: long -> ptr<?>`. In Stanza, `long` is always an signed 64 bit integer, whereas in C `long` can be any integer at least 32 bits wide. Indeed, in C on Windows `long` is a 32-bit signed integer and on Linux `long` is a 64-bit signed integer.

In order to control the representation of types passed along the boundary, this patch introduces `stz_*` types (e.g. `stz_long`) whose representation matches exactly that of the corresponding type in Stanza. These types should be used at the boundary between C and Stanza in order to prevent size/signedness issues. For example, the above `stz_malloc` becomes `void* stz_malloc(stz_long)`. Additionally included are also a set of macros for conversion between Stanza strings (`stz_byte*`) and C-strings (`char*`).