### PR TITLE
Allowed single file input in `definitions-database`

### DIFF
--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -21,7 +21,7 @@ defpackage stz/defs-db :
 ;============================================================
 
 public defstruct DefsDbInput :
-  proj-files: Tuple<String>
+  files: Tuple<String>
   platform: Symbol|False
   flags: Tuple<Symbol>
   optimize?: True|False
@@ -34,12 +34,13 @@ public defn defs-db (input:DefsDbInput, filename:String) :
     (f:False) : OUTPUT-PLATFORM
     
   ;Read all listed packages from given project files
-  val proj-file = read-proj-files(proj-files(input), db-platform)
+  val proj-file = read-proj-files(filter(suffix?{_, ".proj"}, files(input)), db-platform)
   val input-packages = all-packages(proj-file)
 
   ;Construct build settings
   val proj-files-and-packages = to-tuple $
-    cat(proj-files(input), input-packages)
+    cat(files(input), input-packages)
+  
   val build-settings = BuildSettings(
     BuildPackages(proj-files-and-packages), ;inputs
     [],                                     ;vm-packages

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -814,9 +814,9 @@ defn defs-db-command () :
   ;Verify arguments
   defn verify-args (cmd-args:CommandArgs) :
     defn ensure-proj-file! (file:String) :
-      if not suffix?(file, ".proj") :
+      if not (suffix?(file, ".proj") or suffix?(file, ".stanza")) :
         throw(ArgParseError("File %~ is not a valid file for building definitions database. \
-                             A project file (.proj) is expected." % [file]))                         
+                             A project file (.proj) or source (.stanza) is expected." % [file]))                         
     do(ensure-proj-file!, args(cmd-args))    
   
   ;Main action for command
@@ -839,11 +839,10 @@ defn defs-db-command () :
 
   ;Command definition
   Command("definitions-database",
-          AtLeastOneArg, "the .proj files to use to generate definitions for.",
-          to-tuple $ cat(new-flags, common-stanza-flags(["platform", "flags", "optimize"])),
+          AtLeastOneArg, "the .proj or .stanza files to use to generate definitions for.",
+          to-tuple $ cat(new-flags, common-stanza-flags(["platform", "flags", "verbose"])),
           defs-db-msg, false, verify-args, intercept-no-match-exceptions(defs-db-action))
  
-
 ;============================================================
 ;================== Check Docs Command ======================
 ;============================================================


### PR DESCRIPTION
This PR extends the `definitions-database`: 

- Allow the `-verbose` flag to be passed
- Allows individual `.stanza` files as inputs

This allows the command to index definitions for source files as needed. 