### PR TITLE
Windows runtime support

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -7828,141 +7828,112 @@ defn SystemCallException (msg:String) :
     defmethod print (o:OutputStream, this) :
       print(o, msg)
 
-#if-defined(PLATFORM-WINDOWS) :
-  #for (F in splice([
-         (Process (filename:String, args:Seqable<String>,
-                   input:StreamSpecifier, output:StreamSpecifier, error:StreamSpecifier))
-         (Process (filename:String, args:Seqable<String>))
-         (input-stream (p:Process))
-         (output-stream (p:Process))
-         (error-stream (p:Process))
-         (state (p:Process))])) :
-    public defn F :
-      fatal("Process library not yet supported on Windows.")
+;                           Constructor
+;                           ===========
+public lostanza defn Process (filename:ref<String>,
+                              args0:ref<Seqable<String>>,
+                              input:ref<StreamSpecifier>,
+                              output:ref<StreamSpecifier>,
+                              error:ref<StreamSpecifier>) -> ref<Process> :
+  ensure-valid-stream-specifiers(input, output, error)
+  val args = to-tuple(args0)
+  val proc = new Process{0, NEXT-PIPE-ID, null, null, null, false, false, false}
+  NEXT-PIPE-ID = NEXT-PIPE-ID + 1
+  val input_v = value(input).value
+  val output_v = value(output).value
+  val error_v = value(error).value
+  val nargs = args.length
+  val argvs:ptr<ptr<byte>> = call-c clib/stz_malloc((nargs + 1) * sizeof(ptr<?>))
+  argvs[nargs] = null
+  for (var i:long = 0, i < nargs, i = i + 1) :
+    argvs[i] = addr!(args.items[i].chars)
+  val launch_succ = call-c clib/launch_process(addr!(filename.chars), argvs,
+    input_v, output_v, error_v, proc.pipeid, addr!([proc]))
+  if launch_succ != 0 :
+    throw(SystemCallException(linux-error-msg()))
+  return proc
+public defn Process (filename:String, args:Seqable<String>) :
+  Process(filename, args, STANDARD-IN, STANDARD-OUT, STANDARD-ERR)
 
-  public defn call-system (file:String, args:Seqable<String>) -> Int :
-    val args-seq = to-seq(args)
-    fatal("Arguments list is empty.") when empty?(args-seq)
-    next(args-seq) ;Remove first one
-    val cmd = escape-shell-command(cat([file], args-seq))
-    val r = call-system(cmd)
-    throw(SystemCallException(linux-error-msg())) when r != 0
-    r
+defn ensure-valid-stream-specifiers (input:StreamSpecifier, output:StreamSpecifier, error:StreamSpecifier) :
+  if not contains?([STANDARD-IN, PROCESS-IN], input) :
+    fatal("%_ is not a valid input stream specifier." % [input])
+  if not contains?([STANDARD-OUT, PROCESS-OUT, PROCESS-ERR], output) :
+    fatal("%_ is not a valid output stream specifier." % [output])
+  if not contains?([STANDARD-ERR, PROCESS-OUT, PROCESS-ERR], error) :
+    fatal("%_ is not a valid error stream specifier." % [error])
 
-  public defn initialize-process-launcher () :
-    false
+;                            Stream API
+;                            ==========
+public lostanza defn input-stream (p:ref<Process>) -> ref<FileOutputStream> :
+  if p.input-stream == false :
+    if p.input == null : fatal(String("Process has no input stream."))
+    p.input-stream = new FileOutputStream{p.input, 0}
+  return p.input-stream as ref<FileOutputStream>
+public lostanza defn output-stream (p:ref<Process>) -> ref<InputStream> :
+  if p.output-stream == false :
+    if p.output == null : fatal(String("Process has no output stream."))
+    p.output-stream = new FileInputStream{p.output, 0}
+  return p.output-stream as ref<FileInputStream>
+public lostanza defn error-stream (p:ref<Process>) -> ref<InputStream> :
+  if p.error-stream == false :
+    if p.error == null : fatal(String("Process has no error stream."))
+    p.error-stream = new FileInputStream{p.error, 0}
+  return p.error-stream as ref<FileInputStream>
 
-  lostanza defn call-system (cmd:ref<String>) -> ref<Int> :
-    return new Int{call-c clib/system(addr!(cmd.chars))}
+;                          Initialization
+;                          ==============
+public lostanza defn initialize-process-launcher () -> ref<False> :
+  call-c clib/initialize_launcher_process()
+  return false
 
-#else :
+;                            State API
+;                            =========
+lostanza deftype StateStruct :
+  var state: int
+  var code: int
+lostanza defn retrieve-state (p:ref<Process>, wait-for-termination?:ref<True|False>) -> ref<ProcessState> :
+  val s = new StateStruct{0, 0}
+  call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait-for-termination? == true) as int)
 
-  ;                           Constructor
-  ;                           ===========
-  public lostanza defn Process (filename:ref<String>,
-                                args0:ref<Seqable<String>>,
-                                input:ref<StreamSpecifier>,
-                                output:ref<StreamSpecifier>,
-                                error:ref<StreamSpecifier>) -> ref<Process> :
-    ensure-valid-stream-specifiers(input, output, error)
-    val args = to-tuple(args0)
-    val proc = new Process{0, NEXT-PIPE-ID, null, null, null, false, false, false}
-    NEXT-PIPE-ID = NEXT-PIPE-ID + 1
-    val input_v = value(input).value
-    val output_v = value(output).value
-    val error_v = value(error).value
-    val nargs = args.length
-    val argvs:ptr<ptr<byte>> = call-c clib/stz_malloc((nargs + 1) * sizeof(ptr<?>))
-    argvs[nargs] = null
-    for (var i:long = 0, i < nargs, i = i + 1) :
-      argvs[i] = addr!(args.items[i].chars)
-    val launch_succ = call-c clib/launch_process(addr!(filename.chars), argvs,
-      input_v, output_v, error_v, proc.pipeid, addr!([proc]))
-    if launch_succ != 0 :
+  ;State Codes
+  val RUNNING = 0
+  val DONE = 1
+  val TERMINATED = 2
+  val STOPPED = 3
+
+  if s.state != RUNNING and p.pipeid != -1 :
+    val res = call-c clib/delete_process_pipes(p.input, p.output, p.error, p.pipeid)
+    if res < 0 :
       throw(SystemCallException(linux-error-msg()))
-    return proc
-  public defn Process (filename:String, args:Seqable<String>) :
-    Process(filename, args, STANDARD-IN, STANDARD-OUT, STANDARD-ERR)
-
-  defn ensure-valid-stream-specifiers (input:StreamSpecifier, output:StreamSpecifier, error:StreamSpecifier) :
-    if not contains?([STANDARD-IN, PROCESS-IN], input) :
-      fatal("%_ is not a valid input stream specifier." % [input])
-    if not contains?([STANDARD-OUT, PROCESS-OUT, PROCESS-ERR], output) :
-      fatal("%_ is not a valid output stream specifier." % [output])
-    if not contains?([STANDARD-ERR, PROCESS-OUT, PROCESS-ERR], error) :
-      fatal("%_ is not a valid error stream specifier." % [error])
-
-  ;                            Stream API
-  ;                            ==========
-  public lostanza defn input-stream (p:ref<Process>) -> ref<FileOutputStream> :
-    if p.input-stream == false :
-      if p.input == null : fatal(String("Process has no input stream."))
-      p.input-stream = new FileOutputStream{p.input, 0}
-    return p.input-stream as ref<FileOutputStream>
-  public lostanza defn output-stream (p:ref<Process>) -> ref<InputStream> :
-    if p.output-stream == false :
-      if p.output == null : fatal(String("Process has no output stream."))
-      p.output-stream = new FileInputStream{p.output, 0}
-    return p.output-stream as ref<FileInputStream>
-  public lostanza defn error-stream (p:ref<Process>) -> ref<InputStream> :
-    if p.error-stream == false :
-      if p.error == null : fatal(String("Process has no error stream."))
-      p.error-stream = new FileInputStream{p.error, 0}
-    return p.error-stream as ref<FileInputStream>
-
-  ;                          Initialization
-  ;                          ==============
-  public lostanza defn initialize-process-launcher () -> ref<False> :
-    call-c clib/initialize_launcher_process()
-    return false
-
-  ;                            State API
-  ;                            =========
-  lostanza deftype StateStruct :
-    var state: int
-    var code: int
-  lostanza defn retrieve-state (p:ref<Process>, wait-for-termination?:ref<True|False>) -> ref<ProcessState> :
-    val s = new StateStruct{0, 0}
-    call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait-for-termination? == true) as int)
-
-    ;State Codes
-    val RUNNING = 0
-    val DONE = 1
-    val TERMINATED = 2
-    val STOPPED = 3
-
-    if s.state != RUNNING and p.pipeid != -1 :
-      val res = call-c clib/delete_process_pipes(p.input, p.output, p.error, p.pipeid)
-      if res < 0 :
-        throw(SystemCallException(linux-error-msg()))
-      p.pipeid = -1
-      
-    ;Translation
-    if s.state == RUNNING :
-      return ProcessRunning()
-    else if s.state == DONE :
-      return ProcessDone(new Int{s.code})
-    else if s.state == TERMINATED :
-      return ProcessTerminated(new Int{s.code})
-    else if s.state == STOPPED :
-      return ProcessStopped(new Int{s.code})
-    else :
-      return fatal(String("Unreachable"))
-
-  public defn state (p:Process) :
-    retrieve-state(p, false)
+    p.pipeid = -1
     
-  public defn* wait (p:Process) :    
-    val s = retrieve-state(p, true)
-    match(s:ProcessRunning) : wait(p)
-    else : s
+  ;Translation
+  if s.state == RUNNING :
+    return ProcessRunning()
+  else if s.state == DONE :
+    return ProcessDone(new Int{s.code})
+  else if s.state == TERMINATED :
+    return ProcessTerminated(new Int{s.code})
+  else if s.state == STOPPED :
+    return ProcessStopped(new Int{s.code})
+  else :
+    return fatal(String("Unreachable"))
 
-  ;                         System Call API
-  ;                         ===============
-  public defn call-system (file:String, args:Seqable<String>) -> Int :
-    match(wait(Process(file, args))) :
-      (s:ProcessDone) : value(s)
-      (s) : throw(ProcessAbortedError(s))
+public defn state (p:Process) :
+  retrieve-state(p, false)
+
+public defn* wait (p:Process) :
+  val s = retrieve-state(p, true)
+  match(s:ProcessRunning) : wait(p)
+  else : s
+
+;                         System Call API
+;                         ===============
+public defn call-system (file:String, args:Seqable<String>) -> Int :
+  match(wait(Process(file, args))) :
+    (s:ProcessDone) : value(s)
+    (s) : throw(ProcessAbortedError(s))
 
 ;============================================================
 ;=========== Call System and Retrieve Output ================

--- a/runtime/common.h
+++ b/runtime/common.h
@@ -1,0 +1,10 @@
+#ifndef RUNTIME_COMMON_H
+#define RUNTIME_COMMON_H
+
+#include "types.h"
+
+//Stanza Alloc
+void* stz_malloc (stz_long size);
+void stz_free (void* ptr);
+
+#endif

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -1,7 +1,8 @@
 #ifdef PLATFORM_WINDOWS
-  #include<Windows.h>
+  #include<windows.h>
 #else
   #include<sys/wait.h>
+  #include<sys/mman.h>
 #endif
 #include<stdint.h>
 #include<unistd.h>
@@ -14,7 +15,6 @@
 #include<string.h>
 #include<sys/stat.h>
 #include<sys/types.h>
-#include<sys/mman.h>
 #include<dirent.h>
 #include<pthread.h>
 

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -617,7 +617,7 @@ void stz_memory_resize (void* p, stz_long old_size, stz_long new_size) {
 
 //Set protection bits on address range p (inclusive) to p + size (exclusive).
 //Fatal error if size > 0 and protect fails.
-static void protect(void* p, stz_long size, stz_int prot) {
+static void protect(void* p, stz_long size, int prot) {
   if (size == 0) {
     return;
   }
@@ -630,10 +630,10 @@ static void protect(void* p, stz_long size, stz_int prot) {
 //Allocates a segment of memory that is min_size allocated, and can be
 //resized up to max_size.
 void* stz_memory_map (stz_long min_size, stz_long max_size) {
-  void *p = mmap(NULL, (size_t)max_size, STZ_MPROTECT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  void *p = mmap(NULL, (size_t)max_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (p == MAP_FAILED) exit_with_error();
 
-  protect(p, min_size, PROT_EXEC | PROT_WRITE | PROT_READ);
+  protect(p, min_size, PROT_READ | PROT_WRITE | PROT_EXEC);
   return p;
 }
 

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -350,6 +350,18 @@ void stringlist_add (StringList* list, const stz_byte* string){
 //================== Directory Handling ======================
 //============================================================
 
+#ifdef PLATFORM_WINDOWS
+// `stat()` doesn't exist on Windows, but _stat *does*, and
+// symlinks (as far as I can tell) aren't used.
+#define stat _stat
+#define lstat _stat
+#define S_ISLNK(x) 0
+
+stz_int symlink(const stz_byte* target, const stz_byte* linkpath) {
+  return -1;
+}
+#endif
+
 stz_int get_file_type (const stz_byte* filename, stz_int follow_sym_links) {
   struct stat filestat;  
   int result;

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -958,11 +958,12 @@ void retrieve_process_state (stz_long pid, ProcessState* s, stz_int wait_for_ter
   //Read back process state
   read_process_state(launcher_out, s);
 }
-
-#endif
+#else
+#include "process-win32.c"
 //============================================================
 //============== End Process Runtime =========================
 //============================================================
+#endif
 
 #define STACK_TYPE 6
 

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -29,10 +29,31 @@
 static void init_fmalloc ();
 #endif
 
+#ifdef PLATFORM_WINDOWS
+#define exit_with_error() exit_with_error_line_and_func(__FILE__, __LINE__)
+static void exit_with_error_line_and_func(const char* file, int line) {
+  char* lpMsgBuf;
+
+  FormatMessage(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER |
+      FORMAT_MESSAGE_FROM_SYSTEM |
+      FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL,
+      GetLastError(),
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (char*)&lpMsgBuf,
+      0, NULL );
+  fprintf(stderr, "[%s:%d] %s", file, line, lpMsgBuf);
+  LocalFree(lpMsgBuf);
+
+  exit(-1);
+}
+#else
 static void exit_with_error (){
   fprintf(stderr, "%s\n", strerror(errno));
   exit(-1);
 }
+#endif
 
 //     Stanza Defined Entities
 //     =======================

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -995,8 +995,8 @@ int main (int argc, char* argv[]) {
   VMInit init;
 
   //Allocate heap and freespace
-  const int initial_heap_size = 1024 * 1024;
-  const long maximum_heap_size = 4L * 1024 * 1024 * 1024;
+  const stz_long initial_heap_size = 1024 * 1024;
+  const stz_long maximum_heap_size = STZ_LONG(4) * 1024 * 1024 * 1024;
 
   init.heap = (stz_byte*)stz_memory_map(initial_heap_size, maximum_heap_size);
   init.heap_limit = init.heap + initial_heap_size;

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -18,6 +18,7 @@
 #include<dirent.h>
 #include<pthread.h>
 
+#include "common.h"
 #include "types.h"
 
 //       Forward Declarations
@@ -25,9 +26,6 @@
 
 //FMalloc Debugging
 static void init_fmalloc ();
-
-void* stz_malloc (stz_long size);
-void stz_free (void* ptr);
 
 //     Stanza Defined Entities
 //     =======================

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -25,7 +25,9 @@
 //       ====================
 
 //FMalloc Debugging
+#ifdef FMALLOC
 static void init_fmalloc ();
+#endif
 
 //     Stanza Defined Entities
 //     =======================
@@ -178,6 +180,7 @@ stz_long file_time_modified (const stz_byte* filename){
   return 0;
 }
 
+#ifdef FMALLOC
 //============================================================
 //======================= Free List ==========================
 //============================================================
@@ -296,6 +299,7 @@ static void ffree (void* ptr){
   Chunk* c = (Chunk*)((char*)ptr - sizeof(Chunk));
   add_item(&mem_chunks, c);
 }
+#endif
 
 //============================================================
 //===================== String List ==========================

--- a/runtime/linenoise-win32.c
+++ b/runtime/linenoise-win32.c
@@ -1,0 +1,48 @@
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+
+void linenoiseSetMultiLine(int b) {
+  /* stub */
+}
+
+char* getline(void) {
+  char* buffer = NULL;
+  size_t chars_read = 0;
+  size_t buffer_size = 0;
+
+  while (true) {
+    int c = fgetc(stdin);
+    if (c == EOF || c == '\n') {
+      break;
+    }
+    if (buffer == NULL) {
+      buffer = malloc(256);
+      buffer_size = 256;
+    }
+    if (chars_read >= buffer_size) {
+      buffer_size += 256;
+      buffer = realloc(buffer, buffer_size);
+    }
+    buffer[chars_read] = (char) c;
+    chars_read++;
+  }
+  buffer[chars_read] = '\0';
+
+  return buffer;
+}
+
+char* linenoise(const char* prompt) {
+  fflush(stdout);
+  fputs(prompt, stdout);
+  fflush(stdout);
+
+  return getline();
+}
+
+int linenoiseHistoryAdd(const char *line) {
+  /* stub */
+  return -1;
+}

--- a/runtime/linenoise.c
+++ b/runtime/linenoise.c
@@ -1,3 +1,6 @@
+#ifdef PLATFORM_WINDOWS
+#include "linenoise-win32.c"
+#else
 /* linenoise.c -- guerrilla line editing library against the idea that a
  * line editing lib needs to be 20,000 lines of C code.
  *
@@ -1199,3 +1202,4 @@ int linenoiseHistoryLoad(const char *filename) {
     fclose(fp);
     return 0;
 }
+#endif

--- a/runtime/process-win32.c
+++ b/runtime/process-win32.c
@@ -1,0 +1,413 @@
+#include <windows.h>
+#include <namedpipeapi.h>
+#include <processthreadsapi.h>
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "common.h"
+#include "process.h"
+#include "types.h"
+
+static char* allocating_sprintf(const char *restrict fmt, ...) {
+  char* string;
+  size_t bytes_needed;
+  va_list args;
+
+  va_start(args, fmt);
+
+  bytes_needed = vsnprintf(NULL, 0, fmt, args);
+  string = (char*)stz_malloc(bytes_needed + 1);
+  vsprintf(string, fmt, args);
+
+  va_end(args);
+
+  return string;
+}
+
+typedef enum {
+  FT_READ,
+  FT_WRITE
+} FileType;
+
+static FILE* file_from_handle(HANDLE handle, FileType type) {
+  int fd;
+  int osflags;
+  char* mode;
+  FILE* file;
+
+  switch (type) {
+    case FT_READ:  osflags = _O_RDONLY | _O_BINARY; break;
+    case FT_WRITE: osflags = _O_WRONLY | _O_BINARY; break;
+  }
+
+  switch (type) {
+    case FT_READ:  mode = "rb"; break;
+    case FT_WRITE: mode = "wb"; break;
+  }
+
+  fd = _open_osfhandle((intptr_t)handle, osflags);
+  if (fd == -1) return NULL;
+
+  file = _fdopen(fd, mode);
+  if (file == NULL) return NULL;
+
+  setvbuf(file, NULL, _IONBF, 0);
+
+  return file;
+}
+
+// Takes a NULL-terminated list of strings and concatenates them using ' ' as a
+// separator. This is necessary because CreateProcess doesn't take an argument
+// list, but instead expects a string containing the current command line.
+static char* create_command_line_from_argv(const stz_byte** argv) {
+  char* ret;
+  char* cursor;
+  bool first;
+  size_t total_length;
+
+  total_length = 0;
+  for (const stz_byte** arg = argv; *arg != NULL; ++arg) {
+    total_length += strlen(C_CSTR(*arg)) + 3; // +1 for the trailing ' ' or '\0',
+                                              // +2 for the enclosing '"'s
+  }
+
+  ret = (char*)stz_malloc(total_length);
+
+  cursor = ret;
+  first = true;
+  for (const stz_byte** arg = argv; *arg != NULL; ++arg) {
+    if (!first) *cursor++ = ' ';
+    first = false;
+
+    *cursor++ = '"';
+    for (const stz_byte* c = *arg; *c != '\0'; ++c) {
+      *cursor++ = (char)*c;
+    }
+    *cursor++ = '"';
+  }
+  *cursor++ = '\0';
+
+  return ret;
+}
+
+// Split a given string into a list of strings according to a delimeter
+static StringList* split_string(const char* str, char delimeter) {
+  StringList* list;
+  const char *start, *end;
+  char *current;
+
+  list = make_stringlist(1);
+  start = str;
+  while ((end = strchr(start, delimeter)) != NULL) {
+    current = (char*)stz_malloc(end - start + 1);
+    strncpy(current, start, end - start);
+    current[end - start] = '\0';
+
+    stringlist_add(list, STZ_CSTR(current));
+    stz_free(current);
+
+    start = ++end;
+  }
+
+  return list;
+}
+
+static bool is_executable_path(const char* path) {
+  DWORD binary_type;
+  return GetBinaryTypeA(path, &binary_type) &&
+    (binary_type == SCS_32BIT_BINARY ||
+     binary_type == SCS_64BIT_BINARY);
+}
+
+// Iterate over all the directories in PATH and determine in which directory
+// there exists an executable with the given file name. If one is found, return
+// it, otherwise return NULL.
+static LPSTR find_candidate_in_path(const char* file) {
+  StringList* candidates;
+  const char *candidate_dir;
+  char *candidate_path, *candidate_exe_path, *ret;
+
+  ret = NULL;
+
+  candidates = split_string(getenv("PATH"), ';');
+  for (int i = 0; i < candidates->n; ++i) {
+    candidate_dir = C_CSTR(candidates->strings[i]);
+
+    // First check if the given file as-is is an executable path
+    candidate_path = allocating_sprintf("%s\\%s", candidate_dir, file);
+    if (is_executable_path(candidate_path)) {
+      ret = candidate_path;
+      break;
+    }
+    stz_free(candidate_path);
+
+    // Otherwise, check if the file with ".exe" appended is an executable path
+    candidate_exe_path = allocating_sprintf("%s\\%s.exe", candidate_dir, file);
+    if (is_executable_path(candidate_exe_path)) {
+      ret = candidate_exe_path;
+      break;
+    }
+    stz_free(candidate_exe_path);
+  }
+
+  free_stringlist(candidates);
+  return ret;
+}
+
+static bool contains_path_separator(const char* file) {
+  // Windows accepts both '/' and '\' in most APIs
+  return strchr(file, '\\') != NULL ||
+         strchr(file, '/')  != NULL;
+}
+
+// Accept a path which may be relative (e.g. contains '..' or '.') and contain
+// forward-slashes, and convert it to an absolute path with back-slashes
+static char* normalize_path(const char* file) {
+  char* normalized_path;
+
+  normalized_path = (char*)malloc(MAX_PATH * sizeof(char));
+  if (!GetFullPathName(file, MAX_PATH, normalized_path, NULL)) {
+    return NULL;
+  }
+
+  return normalized_path;
+}
+
+void initialize_launcher_process (void) { /* stub */ }
+
+void retrieve_process_state (stz_long pid, ProcessState* s, stz_int wait_for_termination) {
+  ProcessState state;
+  HANDLE process;
+  DWORD exit_code;
+
+  state = (ProcessState){PROCESS_RUNNING, 0};
+
+  process = OpenProcess(PROCESS_QUERY_INFORMATION | SYNCHRONIZE, FALSE, (DWORD)pid);
+  if (process == NULL) {
+    goto END;
+  }
+
+  if (wait_for_termination == 1) {
+    if (WaitForSingleObject(process, INFINITE) == WAIT_FAILED) {
+      goto END;
+    }
+  }
+
+  if (!GetExitCodeProcess(process, &exit_code)) {
+    goto END;
+  }
+
+  if (exit_code != STILL_ACTIVE) {
+    state = (ProcessState){PROCESS_DONE, (stz_int)exit_code};
+  }
+
+END:
+  *s = state;
+}
+
+typedef enum {
+  PIPE_IN,
+  PIPE_OUT
+} PipeType;
+
+static void create_pipe(PHANDLE read, PHANDLE write, PipeType type) {
+  SECURITY_ATTRIBUTES security_attrs;
+  PHANDLE our_end;
+
+  ZeroMemory(&security_attrs, sizeof(SECURITY_ATTRIBUTES));
+  security_attrs.nLength = sizeof(SECURITY_ATTRIBUTES);
+  security_attrs.lpSecurityDescriptor = NULL;
+  security_attrs.bInheritHandle = TRUE;
+
+  switch (type) {
+    case PIPE_IN:  our_end = read;  break;
+    case PIPE_OUT: our_end = write; break;
+  }
+
+  CreatePipe(read, write, &security_attrs, 0);
+  SetHandleInformation(*our_end, HANDLE_FLAG_INHERIT, 0);
+}
+
+static HANDLE duplicate_standard_handle(int handle) {
+  HANDLE ret;
+
+  if (!DuplicateHandle(
+        /* hSourceProcessHandle */ GetCurrentProcess(),
+        /* hSourceHandle        */ GetStdHandle(handle),
+        /* hTargetProcessHandle */ GetCurrentProcess(),
+        /* lpTargetHandle       */ &ret,
+        /* dwDesiredAccess      */ 0,
+        /* bInheritHandle       */ TRUE,
+        /* dwOptions            */ DUPLICATE_SAME_ACCESS)) {
+    return NULL;
+  }
+
+  return ret;
+}
+
+static void setup_file_handles(
+    stz_int input, stz_int output, stz_int error,
+    PHANDLE process_stdin_read, PHANDLE process_stdin_write,
+    PHANDLE process_stdout_read, PHANDLE process_stdout_write,
+    PHANDLE process_stderr_read, PHANDLE process_stderr_write) {
+
+  HANDLE stdin_read, stdin_write,
+         stdout_read, stdout_write,
+         stderr_read, stderr_write;
+
+  // Initialize all our handles to NULL (just in case)
+  *process_stdin_read   = NULL;
+  *process_stdin_write  = NULL;
+  *process_stdout_read  = NULL;
+  *process_stdout_write = NULL;
+  *process_stderr_read  = NULL;
+  *process_stderr_write = NULL;
+
+  // Compute which pipes we want to open
+  int pipe_sources[NUM_STREAM_SPECS] = { -1 };
+  pipe_sources[input]  = 0;
+  pipe_sources[output] = 1;
+  pipe_sources[error]  = 2;
+
+  // Open the pipes we requested
+  if (pipe_sources[PROCESS_IN] >= 0) {
+    create_pipe(&stdin_read, &stdin_write, PIPE_OUT);
+  }
+  if (pipe_sources[PROCESS_OUT] >= 0) {
+    create_pipe(&stdout_read, &stdout_write, PIPE_IN);
+  }
+  if (pipe_sources[PROCESS_ERR] >= 0) {
+    create_pipe(&stderr_read, &stderr_write, PIPE_IN);
+  }
+
+  // Input can either be redirected to an IN pipe or re-use parent's STDIN
+  if (input == PROCESS_IN) {
+    *process_stdin_read  = stdin_read;
+    *process_stdin_write = stdin_write;
+  }
+  else {
+    *process_stdin_read  = duplicate_standard_handle(STD_INPUT_HANDLE);
+    *process_stdin_write = NULL;
+  }
+
+  // Output can be redirected to an OUT or ERR pipe or re-use parent's STDOUT
+  if (output == PROCESS_OUT) {
+    *process_stdout_read  = stdout_read;
+    *process_stdout_write = stdout_write;
+  }
+  else if (output == PROCESS_ERR) {
+    *process_stderr_read  = stdout_read;
+    *process_stderr_write = stdout_write;
+  }
+  else {
+    *process_stdout_read  = NULL;
+    *process_stdout_write = duplicate_standard_handle(STD_OUTPUT_HANDLE);
+  }
+
+  // Error can be redirected to an OUT or ERR pipe or re-use parent's STDERR
+  if (error == PROCESS_OUT) {
+    *process_stderr_read  = stdout_read;
+    *process_stderr_write = stdout_write;
+  }
+  else if (error == PROCESS_ERR) {
+    *process_stderr_read  = stderr_read;
+    *process_stderr_write = stderr_write;
+  }
+  else {
+    *process_stderr_read  = NULL;
+    *process_stderr_write = duplicate_standard_handle(STD_ERROR_HANDLE);
+  }
+}
+
+stz_int launch_process(const stz_byte* file, const stz_byte** argvs,
+                       stz_int input, stz_int output, stz_int error,
+                       stz_int pipeid, Process* process) {
+  const char* file_str;
+  LPSTR command_line, executable;
+  PROCESS_INFORMATION proc_info;
+  STARTUPINFO start_info;
+  HANDLE stdin_read, stdin_write,
+         stdout_read, stdout_write,
+         stderr_read, stderr_write;
+  BOOL success;
+
+  // Create a command line using the given argv. This is necessary because
+  // Window's CreateProcess expects a full command-line (process name +
+  // arguments), rather than passing in a list of args (like exec* on POSIX)
+  command_line = (LPSTR)create_command_line_from_argv(argvs);
+
+  // Find an executable path using the given file. If we were given a path,
+  // normalize it, in case it is relative or has forward-slashes If it's a
+  // file, find the path of a corresponding executable on PATH
+  file_str = C_CSTR(file);
+  executable = contains_path_separator(file_str)
+    ? normalize_path(file_str)
+    : find_candidate_in_path(file_str);
+
+  if (command_line == NULL || executable == NULL) {
+    success = FALSE;
+    goto END;
+  }
+
+  // Set up our STDIN, STDOUT, and STDERR
+  setup_file_handles(input, output, error,
+      &stdin_read, &stdin_write,
+      &stdout_read, &stdout_write,
+      &stderr_read, &stderr_write
+  );
+
+  // Now that we have our handles, set up STARTUPINFO so that the child process will use them
+  ZeroMemory(&start_info, sizeof(STARTUPINFO));
+  start_info.cb = sizeof(STARTUPINFO);
+  start_info.hStdInput  = stdin_read;
+  start_info.hStdOutput = stdout_write;
+  start_info.hStdError  = stderr_write;
+  start_info.dwFlags |= STARTF_USESTDHANDLES;
+
+  // Zero out our process information in ancipication of CreateProcess
+  // populating it, and then launch our process.
+  ZeroMemory(&proc_info, sizeof(PROCESS_INFORMATION));
+  success = CreateProcess(
+      /* lpApplicationName    */ executable,
+      /* lpCommandLine        */ command_line,
+      /* lpProcessAttributes  */ NULL,
+      /* lpThreadAttributes   */ NULL,
+      /* bInheritHandles      */ TRUE,
+      /* dwCreationFlags      */ 0,
+      /* lpEnvironment        */ NULL,
+      /* lpCurrentDirectory   */ NULL,
+      /* lpStartupInfo        */ &start_info,
+      /* lpProcessInformation */ &proc_info);
+
+END:
+  stz_free(executable);
+  stz_free(command_line);
+
+  if (success) {
+    // Populate process with the relevant info
+    process->pid = (stz_long)proc_info.dwProcessId;
+    process->pipeid = -1; // -1 signals we didn't create named pipes for this process
+    process->in  = file_from_handle(stdin_write, FT_WRITE);
+    process->out = file_from_handle(stdout_read, FT_READ);
+    process->err = file_from_handle(stderr_read, FT_READ);
+
+    // Close the handles we passed into the child process
+    if (stdin_read   != NULL) CloseHandle(stdin_read);
+    if (stdout_write != NULL) CloseHandle(stdout_write);
+    if (stderr_write != NULL) CloseHandle(stderr_write);
+
+    // Close these left-over handles to the process
+    CloseHandle(proc_info.hThread);
+    CloseHandle(proc_info.hProcess);
+  }
+
+  return success ? 0 : -1;
+}
+
+stz_int delete_process_pipes (FILE* input, FILE* output, FILE* error, stz_int pipeid) {
+  return 0;
+}

--- a/runtime/process.h
+++ b/runtime/process.h
@@ -1,0 +1,34 @@
+#ifndef RUNTIME_PROCESS_H
+#define RUNTIME_PROCESS_H
+
+#include <stdio.h>
+
+#include "types.h"
+
+typedef struct {
+  stz_long pid;
+  stz_int pipeid;
+  FILE* in;
+  FILE* out;
+  FILE* err;
+} Process;
+
+typedef struct {
+  stz_int state;
+  stz_int code;
+} ProcessState;
+
+#define PROCESS_RUNNING 0
+#define PROCESS_DONE 1
+#define PROCESS_TERMINATED 2
+#define PROCESS_STOPPED 3
+
+#define STANDARD_IN 0
+#define STANDARD_OUT 1
+#define PROCESS_IN 2
+#define PROCESS_OUT 3
+#define STANDARD_ERR 4
+#define PROCESS_ERR 5
+#define NUM_STREAM_SPECS 6
+
+#endif

--- a/runtime/types.h
+++ b/runtime/types.h
@@ -20,4 +20,13 @@ typedef float   stz_float;
 #define STZ_STR(x)  ((stz_byte*)(x))
 #define STZ_CSTR(x) ((const stz_byte*)(x))
 
+// Macro to create an integer literal of size `stz_long`. Using LL is probably
+// always OK but using an explicit macro helps keep definition/declarations in
+// sync. (compare `stz_long i = 4LL` to `stz_long i = STZ_LONG(4)`)
+#ifdef PLATFORM_WINDOWS
+#define STZ_LONG(N) ((stz_long)N##LL)
+#else
+#define STZ_LONG(N) ((stz_long)N##L)
+#endif
+
 #endif


### PR DESCRIPTION
This patch implements/improves Stanza runtime support for Windows. Previously the runtime would not build under Windows (due to changes made in the interim), however with these changes applied I have been able to successfully build the compiler (on Linux using cross-compilation) and then build the compiler with itself.

Things implemented in this PR:
* Windows process library
* Windows linenoise library (stubbed)
* Windows resizeable memory regions support
* Windows path support (not necessarily comprehensive)