### PR TITLE
globally compute uses, defs, and elim-vars ahead of eliminating instructions

### DIFF
--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -78,8 +78,8 @@ defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
     run-pass("Convert Checks to Typeof", convert-checks-to-typeof, "typeof", false)
   run-pass("Box Mutables", box-mutables, "boxed", false)
   run-pass("Detect Loops", detect-loops, "looped", false)
-  run-pass("Simple Inline", simple-inline, "inlined", false)
-  run-pass("Within Package Inline", within-package-inline{_, true}, "wp-inlined", false)
+  run-pass("Simple Inline", simple-inline, "inlined0", false)
+  run-pass("Within Package Inline", within-package-inline{_, true}, "wp-inlined0", false)
   run-pass("Cleanup Labels", cleanup-labels, "cleanup-labels", false)
   if optimize? :
     run-pass("Remove Reified Types", force-remove-types, "removed-types", true)
@@ -88,19 +88,19 @@ defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
   if optimize? :
     run-pass("Resolve Methods", resolve-methods, "resolved-methods", false)
     ;Phase 1
-    run-pass("Simple Inline", simple-inline, "inlined", false)
-    run-pass("Within Package Inline", within-package-inline{_, false}, "wp-inlined", false)
-    run-pass("Cleanup Labels", cleanup-labels, "cleanup-labels", false)
-    run-pass("Beta Reduce", beta-reduce, "beta-reduce", false)
-    run-pass("Box Unbox", box-unbox-fold, "box-unbox", false)
-    run-pass("Eliminate Dead Code", eliminate-dead-code, "dead-code", false)
+    run-pass("Simple Inline", simple-inline, "inlined1", false)
+    run-pass("Within Package Inline", within-package-inline{_, false}, "wp-inlined1", false)
+    run-pass("Cleanup Labels", cleanup-labels, "cleanup-labels1", false)
+    run-pass("Beta Reduce", beta-reduce, "beta-reduce1", false)
+    run-pass("Box Unbox", box-unbox-fold, "box-unbox1", false)
+    run-pass("Eliminate Dead Code", eliminate-dead-code, "dead-code1", false)
     ;Phase 2
-    run-pass("Simple Inline", simple-inline, "inlined", false)
-    run-pass("Within Package Inline", within-package-inline{_, false}, "wp-inlined", false)
-    run-pass("Cleanup Labels", cleanup-labels, "cleanup-labels", false)
-    run-pass("Beta Reduce", beta-reduce, "beta-reduce", false)
-    run-pass("Box Unbox", box-unbox-fold, "box-unbox", false)
-    run-pass("Eliminate Dead Code", eliminate-dead-code, "dead-code", false)
+    run-pass("Simple Inline", simple-inline, "inlined2", false)
+    run-pass("Within Package Inline", within-package-inline{_, false}, "wp-inlined2", false)
+    run-pass("Cleanup Labels", cleanup-labels, "cleanup-labels2", false)
+    run-pass("Beta Reduce", beta-reduce, "beta-reduce2", false)
+    run-pass("Box Unbox", box-unbox-fold, "box-unbox2", false)
+    run-pass("Eliminate Dead Code", eliminate-dead-code, "dead-code2", false)
   run-pass("Resolve Matches", resolve-matches, "resolved-matches", false)
   run-pass("Lift Closures", lift-closures, "closurelifted", false)
   run-pass("Lift Type Objects", lift-type-objects, "typelifted", false)
@@ -2705,8 +2705,7 @@ defn max (a:UsageType, b:UsageType) -> UsageType :
 ;results are not used at all.
 defn eliminate-dead-code (epackage:EPackage) -> EPackage :
   ;Collect all uses of variables in the given body.
-  defn collect-uses (e:ETExp) -> IntTable<UsageType> :
-    val use-set = IntTable<UsageType>()
+  defn collect-uses (e:ETExp, use-set:IntTable<UsageType>) :
     let loop (e:ELItem = e) :
       match(e:EIns) :
         val usage-type = UsedInLive when e is ELive
@@ -2718,15 +2717,16 @@ defn eliminate-dead-code (epackage:EPackage) -> EPackage :
               (f:False) : usage-type
       else :
         do(loop, e)
-    use-set
 
   ;Collect all definitions of all variables in the given body.
-  defn collect-defs (e:EBody) -> IntListTable<EIns> :
-    val table = IntListTable<EIns>()
-    for i in ins(e) do :
-      for x in varlocs(i) do :
-        add(table, n(x), i)
-    table
+  defn collect-defs (e:ETExp, defs:IntListTable<EIns>) :
+    let loop (e:ELItem = e) :
+      match(e:EBody) :
+        for i in ins(e) do :
+          for x in varlocs(i) do :
+            add(defs, n(x), i)
+      else :      
+        do(loop, e)
 
   ;Compute variables to eliminate.
   defn vars-to-eliminate (table:IntListTable<EIns>, uses:IntTable<UsageType>) -> IntSet :
@@ -2749,34 +2749,35 @@ defn eliminate-dead-code (epackage:EPackage) -> EPackage :
       else : None()      
 
   ;Eliminate dead code in body.
-  defn eliminate-in-item (e:ELBigItem, uses:IntTable<UsageType>) -> ELBigItem :
-    val e* = map(eliminate-in-item{_, uses}, e)
-    match(e*:EBody) :
-      ;Compute variables to eliminate.
-      val elim-vars = vars-to-eliminate(collect-defs(e*), uses)
-      if empty?(elim-vars) :
-        e*
-      else :
-        val buffer = BodyBuffer(e*)
-        for l in locals(e*) do :
-          emit(buffer,l) when not elim-vars[n(l)]
-        for i in ins(e*) do :
-          match(i:ELive) :
-            val xs* = to-tuple $ for x in xs(i) filter :
-              not elim-vars[n(x as EVar)]
-            if not empty?(xs*) :
-              emit(buffer, ELive(xs*))
-          else :
-            val elim? = for v in varlocs(i) any? :
-              elim-vars[n(v)]
-            emit(buffer, i) when not elim?
-        to-body(buffer, false, true, true)
-    else :
-      e*
+  defn eliminate-in-item (e:ELBigItem, uses:IntTable<UsageType>, elim-vars:IntSet) -> ELBigItem :
+    let loop (e:ELBigItem = e) :
+      match(map(loop, e)) :
+        (e:EBody) : 
+          val buffer = BodyBuffer(e)
+          for l in locals(e) do :
+            emit(buffer,l) when not elim-vars[n(l)]
+          for i in ins(e) do :
+            match(i:ELive) :
+              val xs* = to-tuple $ for x in xs(i) filter :
+                not elim-vars[n(x as EVar)]
+              if not empty?(xs*) :
+                emit(buffer, ELive(xs*))
+            else :
+              val elim? = for v in varlocs(i) any? :
+                elim-vars[n(v)]
+              emit(buffer, i) when not elim?
+          to-body(buffer, false, true, true)
+        (e) : e
 
   ;Launch!
+  val defs = IntListTable<EIns>()
+  val uses = IntTable<UsageType>()
+  for e in exps(epackage) do :
+    collect-defs(e, defs)
+    collect-uses(e, uses)
+  val elim-vars = vars-to-eliminate(defs, uses)
   val texps* = for e in exps(epackage) map :
-    eliminate-in-item(e, collect-uses(e)) as ETExp
+    eliminate-in-item(e, uses, elim-vars) as ETExp
   sub-exps(epackage, texps*)
 
 ;============================================================

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1152,7 +1152,7 @@ lostanza defn set-mark (heap:ptr<Heap>, p:ptr<?>) -> ref<False> :
   val address = bit-address(heap, index)
   [address] = [address] | bit-mask(index)
   ;No meaningful return value.
-  return 0
+  return false
 
 ;Marks the given heap pointer in the heap's bitset.
 ;Returns a non-zero value if the pointer was previously marked.


### PR DESCRIPTION
Eliminate-dead-code could miss dead code on functions with nested functions.  The solution is to compute the uses, defs, and vars to eliminate before eliminating the instructions.