### PR TITLE
Windows process library support

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -63,10 +63,13 @@ protected extern stz_memory_unmap: (ptr<?>, long) -> int
 protected extern stz_memory_resize: (ptr<?>, long, long) -> int
 
 ;Process libraries
-protected extern launch_process: (ptr<byte>, ptr<ptr<byte>>, int, int, int, int, ptr<?>) -> int
-protected extern delete_process_pipes: (ptr<?>, ptr<?>, ptr<?>, int) -> int
+#if-defined(PLATFORM-WINDOWS):
+  protected extern launch_process: (ptr<byte>, int, int, int, ptr<?>) -> int
+#else:
+  protected extern launch_process: (ptr<byte>, ptr<ptr<byte>>, int, int, int, int, ptr<?>) -> int
+  protected extern delete_process_pipes: (ptr<?>, ptr<?>, ptr<?>, int) -> int
+  protected extern initialize_launcher_process: () -> int
 protected extern retrieve_process_state: (long, ptr<?>, int) -> int
-protected extern initialize_launcher_process: () -> int
 
 ;Math libraries
 protected extern exp: double -> double
@@ -7828,37 +7831,33 @@ defn SystemCallException (msg:String) :
     defmethod print (o:OutputStream, this) :
       print(o, msg)
 
-#if-defined(PLATFORM-WINDOWS) :
-  #for (F in splice([
-         (Process (filename:String, args:Seqable<String>,
-                   input:StreamSpecifier, output:StreamSpecifier, error:StreamSpecifier))
-         (Process (filename:String, args:Seqable<String>))
-         (input-stream (p:Process))
-         (output-stream (p:Process))
-         (error-stream (p:Process))
-         (state (p:Process))])) :
-    public defn F :
-      fatal("Process library not yet supported on Windows.")
+;                           Constructor
+;                           ===========
+#if-defined(PLATFORM-WINDOWS):
+  public lostanza defn Process (filename:ref<String>,
+                                args0:ref<Seqable<String>>,
+                                input:ref<StreamSpecifier>,
+                                output:ref<StreamSpecifier>,
+                                error:ref<StreamSpecifier>) -> ref<Process> :
+    val proc = new Process{0, -1, null, null, null, false, false, false}
 
-  public defn call-system (file:String, args:Seqable<String>) -> Int :
-    val args-seq = to-seq(args)
-    fatal("Arguments list is empty.") when empty?(args-seq)
-    next(args-seq) ;Remove first one
-    val cmd = escape-shell-command(cat([file], args-seq))
-    val r = call-system(cmd)
-    throw(SystemCallException(linux-error-msg())) when r != 0
-    r
+    ; Create a command line from the given filename and args (discarding the first argument).
+    ; This is necessary because Windows' process API expects a command line (not a list of arguments).
+    ; We discard the first argument because, on Windows, the first argument is used to look-up
+    ; the executable (e.g. in the current directiory, in the PATH, etc.) whereas on POSIX
+    ; it is typically only exists as a convention.
+    val args = cons(filename, tail(to-list(args0)))
+    val command-line = escape-shell-command(args)
 
-  public defn initialize-process-launcher () :
-    false
-
-  lostanza defn call-system (cmd:ref<String>) -> ref<Int> :
-    return new Int{call-c clib/system(addr!(cmd.chars))}
-
-#else :
-
-  ;                           Constructor
-  ;                           ===========
+    val input_v = value(input).value
+    val output_v = value(output).value
+    val error_v = value(error).value
+    val launch_success = call-c clib/launch_process(
+      addr!(command-line.chars), input_v, output_v, error_v, addr!([proc]))
+    if launch_success != 0 :
+      throw(SystemCallException(windows-error-msg()))
+    return proc
+#else:
   public lostanza defn Process (filename:ref<String>,
                                 args0:ref<Seqable<String>>,
                                 input:ref<StreamSpecifier>,
@@ -7881,88 +7880,91 @@ defn SystemCallException (msg:String) :
     if launch_succ != 0 :
       throw(SystemCallException(linux-error-msg()))
     return proc
-  public defn Process (filename:String, args:Seqable<String>) :
-    Process(filename, args, STANDARD-IN, STANDARD-OUT, STANDARD-ERR)
 
-  defn ensure-valid-stream-specifiers (input:StreamSpecifier, output:StreamSpecifier, error:StreamSpecifier) :
-    if not contains?([STANDARD-IN, PROCESS-IN], input) :
-      fatal("%_ is not a valid input stream specifier." % [input])
-    if not contains?([STANDARD-OUT, PROCESS-OUT, PROCESS-ERR], output) :
-      fatal("%_ is not a valid output stream specifier." % [output])
-    if not contains?([STANDARD-ERR, PROCESS-OUT, PROCESS-ERR], error) :
-      fatal("%_ is not a valid error stream specifier." % [error])
+public defn Process (filename:String, args:Seqable<String>) :
+  Process(filename, args, STANDARD-IN, STANDARD-OUT, STANDARD-ERR)
 
-  ;                            Stream API
-  ;                            ==========
-  public lostanza defn input-stream (p:ref<Process>) -> ref<FileOutputStream> :
-    if p.input-stream == false :
-      if p.input == null : fatal(String("Process has no input stream."))
-      p.input-stream = new FileOutputStream{p.input, 0}
-    return p.input-stream as ref<FileOutputStream>
-  public lostanza defn output-stream (p:ref<Process>) -> ref<InputStream> :
-    if p.output-stream == false :
-      if p.output == null : fatal(String("Process has no output stream."))
-      p.output-stream = new FileInputStream{p.output, 0}
-    return p.output-stream as ref<FileInputStream>
-  public lostanza defn error-stream (p:ref<Process>) -> ref<InputStream> :
-    if p.error-stream == false :
-      if p.error == null : fatal(String("Process has no error stream."))
-      p.error-stream = new FileInputStream{p.error, 0}
-    return p.error-stream as ref<FileInputStream>
+defn ensure-valid-stream-specifiers (input:StreamSpecifier, output:StreamSpecifier, error:StreamSpecifier) :
+  if not contains?([STANDARD-IN, PROCESS-IN], input) :
+    fatal("%_ is not a valid input stream specifier." % [input])
+  if not contains?([STANDARD-OUT, PROCESS-OUT, PROCESS-ERR], output) :
+    fatal("%_ is not a valid output stream specifier." % [output])
+  if not contains?([STANDARD-ERR, PROCESS-OUT, PROCESS-ERR], error) :
+    fatal("%_ is not a valid error stream specifier." % [error])
 
-  ;                          Initialization
-  ;                          ==============
-  public lostanza defn initialize-process-launcher () -> ref<False> :
+;                            Stream API
+;                            ==========
+public lostanza defn input-stream (p:ref<Process>) -> ref<FileOutputStream> :
+  if p.input-stream == false :
+    if p.input == null : fatal(String("Process has no input stream."))
+    p.input-stream = new FileOutputStream{p.input, 0}
+  return p.input-stream as ref<FileOutputStream>
+public lostanza defn output-stream (p:ref<Process>) -> ref<InputStream> :
+  if p.output-stream == false :
+    if p.output == null : fatal(String("Process has no output stream."))
+    p.output-stream = new FileInputStream{p.output, 0}
+  return p.output-stream as ref<FileInputStream>
+public lostanza defn error-stream (p:ref<Process>) -> ref<InputStream> :
+  if p.error-stream == false :
+    if p.error == null : fatal(String("Process has no error stream."))
+    p.error-stream = new FileInputStream{p.error, 0}
+  return p.error-stream as ref<FileInputStream>
+
+;                          Initialization
+;                          ==============
+public lostanza defn initialize-process-launcher () -> ref<False> :
+  #if-not-defined(PLATFORM-WINDOWS):
     call-c clib/initialize_launcher_process()
-    return false
+  return false
 
-  ;                            State API
-  ;                            =========
-  lostanza deftype StateStruct :
-    var state: int
-    var code: int
-  lostanza defn retrieve-state (p:ref<Process>, wait-for-termination?:ref<True|False>) -> ref<ProcessState> :
-    val s = new StateStruct{0, 0}
-    call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait-for-termination? == true) as int)
+;                            State API
+;                            =========
+lostanza deftype StateStruct :
+  var state: int
+  var code: int
+lostanza defn retrieve-state (p:ref<Process>, wait-for-termination?:ref<True|False>) -> ref<ProcessState> :
+  val s = new StateStruct{0, 0}
+  call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait-for-termination? == true) as int)
 
-    ;State Codes
-    val RUNNING = 0
-    val DONE = 1
-    val TERMINATED = 2
-    val STOPPED = 3
+  ;State Codes
+  val RUNNING = 0
+  val DONE = 1
+  val TERMINATED = 2
+  val STOPPED = 3
 
+  #if-not-defined(PLATFORM-WINDOWS):
     if s.state != RUNNING and p.pipeid != -1 :
       val res = call-c clib/delete_process_pipes(p.input, p.output, p.error, p.pipeid)
       if res < 0 :
         throw(SystemCallException(linux-error-msg()))
       p.pipeid = -1
-      
-    ;Translation
-    if s.state == RUNNING :
-      return ProcessRunning()
-    else if s.state == DONE :
-      return ProcessDone(new Int{s.code})
-    else if s.state == TERMINATED :
-      return ProcessTerminated(new Int{s.code})
-    else if s.state == STOPPED :
-      return ProcessStopped(new Int{s.code})
-    else :
-      return fatal(String("Unreachable"))
 
-  public defn state (p:Process) :
-    retrieve-state(p, false)
-    
-  public defn* wait (p:Process) :    
-    val s = retrieve-state(p, true)
-    match(s:ProcessRunning) : wait(p)
-    else : s
+  ;Translation
+  if s.state == RUNNING :
+    return ProcessRunning()
+  else if s.state == DONE :
+    return ProcessDone(new Int{s.code})
+  else if s.state == TERMINATED :
+    return ProcessTerminated(new Int{s.code})
+  else if s.state == STOPPED :
+    return ProcessStopped(new Int{s.code})
+  else :
+    return fatal(String("Unreachable"))
 
-  ;                         System Call API
-  ;                         ===============
-  public defn call-system (file:String, args:Seqable<String>) -> Int :
-    match(wait(Process(file, args))) :
-      (s:ProcessDone) : value(s)
-      (s) : throw(ProcessAbortedError(s))
+public defn state (p:Process) :
+  retrieve-state(p, false)
+
+public defn* wait (p:Process) :
+  val s = retrieve-state(p, true)
+  match(s:ProcessRunning) : wait(p)
+  else : s
+
+;                         System Call API
+;                         ===============
+public defn call-system (file:String, args:Seqable<String>) -> Int :
+  match(wait(Process(file, args))) :
+    (s:ProcessDone) : value(s)
+    (s) : throw(ProcessAbortedError(s))
 
 ;============================================================
 ;=========== Call System and Retrieve Output ================

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -434,19 +434,6 @@ void stz_free (void* ptr){
 //------------------------------------------------------------
 
 typedef struct {
-  stz_long pid;
-  stz_int pipeid;
-  FILE* in;
-  FILE* out;
-  FILE* err;
-} Process;
-
-typedef struct {
-  stz_int state;
-  stz_int code;
-} ProcessState;
-
-typedef struct {
   stz_byte* pipe;
   stz_byte* in_pipe;
   stz_byte* out_pipe;
@@ -454,19 +441,6 @@ typedef struct {
   stz_byte* file;
   stz_byte** argvs;
 } EvalArg;
-
-#define PROCESS_RUNNING 0
-#define PROCESS_DONE 1
-#define PROCESS_TERMINATED 2
-#define PROCESS_STOPPED 3
-
-#define STANDARD_IN 0
-#define STANDARD_OUT 1
-#define PROCESS_IN 2
-#define PROCESS_OUT 3
-#define STANDARD_ERR 4
-#define PROCESS_ERR 5
-#define NUM_STREAM_SPECS 6
 
 #define RETURN_NEG(x) {int r=(x); if(r < 0) return -1;}
 
@@ -950,11 +924,12 @@ void retrieve_process_state (stz_long pid, ProcessState* s, stz_int wait_for_ter
   //Read back process state
   read_process_state(launcher_out, s);
 }
-
-#endif
+#else
+#include "process-win32.c"
 //============================================================
 //============== End Process Runtime =========================
 //============================================================
+#endif
 
 #define STACK_TYPE 6
 

--- a/runtime/process-win32.c
+++ b/runtime/process-win32.c
@@ -1,0 +1,248 @@
+#include <windows.h>
+#include <namedpipeapi.h>
+#include <processthreadsapi.h>
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "common.h"
+#include "process.h"
+#include "types.h"
+
+typedef enum {
+  FT_READ,
+  FT_WRITE
+} FileType;
+
+static FILE* file_from_handle(HANDLE handle, FileType type) {
+  int fd;
+  int osflags;
+  char* mode;
+  FILE* file;
+
+  switch (type) {
+    case FT_READ:  osflags = _O_RDONLY | _O_BINARY; break;
+    case FT_WRITE: osflags = _O_WRONLY | _O_BINARY; break;
+  }
+
+  switch (type) {
+    case FT_READ:  mode = "rb"; break;
+    case FT_WRITE: mode = "wb"; break;
+  }
+
+  fd = _open_osfhandle((intptr_t)handle, osflags);
+  if (fd == -1) return NULL;
+
+  file = _fdopen(fd, mode);
+  if (file == NULL) return NULL;
+
+  setvbuf(file, NULL, _IONBF, 0);
+
+  return file;
+}
+
+void retrieve_process_state (stz_long pid, ProcessState* s, stz_int wait_for_termination) {
+  ProcessState state;
+  HANDLE process;
+  DWORD exit_code;
+
+  state = (ProcessState){PROCESS_RUNNING, 0};
+
+  process = OpenProcess(PROCESS_QUERY_INFORMATION | SYNCHRONIZE, FALSE, (DWORD)pid);
+  if (process == NULL) {
+    goto END;
+  }
+
+  if (wait_for_termination == 1) {
+    if (WaitForSingleObject(process, INFINITE) == WAIT_FAILED) {
+      goto END;
+    }
+  }
+
+  if (!GetExitCodeProcess(process, &exit_code)) {
+    goto END;
+  }
+
+  if (exit_code != STILL_ACTIVE) {
+    state = (ProcessState){PROCESS_DONE, (stz_int)exit_code};
+  }
+
+END:
+  *s = state;
+}
+
+typedef enum {
+  PIPE_IN,
+  PIPE_OUT
+} PipeType;
+
+static void create_pipe(PHANDLE read, PHANDLE write, PipeType type) {
+  SECURITY_ATTRIBUTES security_attrs;
+  PHANDLE our_end;
+
+  ZeroMemory(&security_attrs, sizeof(SECURITY_ATTRIBUTES));
+  security_attrs.nLength = sizeof(SECURITY_ATTRIBUTES);
+  security_attrs.lpSecurityDescriptor = NULL;
+  security_attrs.bInheritHandle = TRUE;
+
+  switch (type) {
+    case PIPE_IN:  our_end = read;  break;
+    case PIPE_OUT: our_end = write; break;
+  }
+
+  CreatePipe(read, write, &security_attrs, 0);
+  SetHandleInformation(*our_end, HANDLE_FLAG_INHERIT, 0);
+}
+
+static HANDLE duplicate_standard_handle(int handle) {
+  HANDLE ret;
+
+  if (!DuplicateHandle(
+        /* hSourceProcessHandle */ GetCurrentProcess(),
+        /* hSourceHandle        */ GetStdHandle(handle),
+        /* hTargetProcessHandle */ GetCurrentProcess(),
+        /* lpTargetHandle       */ &ret,
+        /* dwDesiredAccess      */ 0,
+        /* bInheritHandle       */ TRUE,
+        /* dwOptions            */ DUPLICATE_SAME_ACCESS)) {
+    return NULL;
+  }
+
+  return ret;
+}
+
+static void setup_file_handles(
+    stz_int input, stz_int output, stz_int error,
+    PHANDLE process_stdin_read, PHANDLE process_stdin_write,
+    PHANDLE process_stdout_read, PHANDLE process_stdout_write,
+    PHANDLE process_stderr_read, PHANDLE process_stderr_write) {
+
+  HANDLE stdin_read, stdin_write,
+         stdout_read, stdout_write,
+         stderr_read, stderr_write;
+
+  // Initialize all our handles to NULL (just in case)
+  *process_stdin_read   = NULL;
+  *process_stdin_write  = NULL;
+  *process_stdout_read  = NULL;
+  *process_stdout_write = NULL;
+  *process_stderr_read  = NULL;
+  *process_stderr_write = NULL;
+
+  // Compute which pipes we want to open
+  int pipe_sources[NUM_STREAM_SPECS] = { -1 };
+  pipe_sources[input]  = 0;
+  pipe_sources[output] = 1;
+  pipe_sources[error]  = 2;
+
+  // Open the pipes we requested
+  if (pipe_sources[PROCESS_IN] >= 0) {
+    create_pipe(&stdin_read, &stdin_write, PIPE_OUT);
+  }
+  if (pipe_sources[PROCESS_OUT] >= 0) {
+    create_pipe(&stdout_read, &stdout_write, PIPE_IN);
+  }
+  if (pipe_sources[PROCESS_ERR] >= 0) {
+    create_pipe(&stderr_read, &stderr_write, PIPE_IN);
+  }
+
+  // Input can either be redirected to an IN pipe or re-use parent's STDIN
+  if (input == PROCESS_IN) {
+    *process_stdin_read  = stdin_read;
+    *process_stdin_write = stdin_write;
+  }
+  else {
+    *process_stdin_read  = duplicate_standard_handle(STD_INPUT_HANDLE);
+    *process_stdin_write = NULL;
+  }
+
+  // Output can be redirected to an OUT or ERR pipe or re-use parent's STDOUT
+  if (output == PROCESS_OUT) {
+    *process_stdout_read  = stdout_read;
+    *process_stdout_write = stdout_write;
+  }
+  else if (output == PROCESS_ERR) {
+    *process_stderr_read  = stdout_read;
+    *process_stderr_write = stdout_write;
+  }
+  else {
+    *process_stdout_read  = NULL;
+    *process_stdout_write = duplicate_standard_handle(STD_OUTPUT_HANDLE);
+  }
+
+  // Error can be redirected to an OUT or ERR pipe or re-use parent's STDERR
+  if (error == PROCESS_OUT) {
+    *process_stderr_read  = stdout_read;
+    *process_stderr_write = stdout_write;
+  }
+  else if (error == PROCESS_ERR) {
+    *process_stderr_read  = stderr_read;
+    *process_stderr_write = stderr_write;
+  }
+  else {
+    *process_stderr_read  = NULL;
+    *process_stderr_write = duplicate_standard_handle(STD_ERROR_HANDLE);
+  }
+}
+
+stz_int launch_process(stz_byte* command_line, stz_int input, stz_int output, stz_int error, Process* process) {
+  PROCESS_INFORMATION proc_info;
+  STARTUPINFO start_info;
+  HANDLE stdin_read, stdin_write,
+         stdout_read, stdout_write,
+         stderr_read, stderr_write;
+  BOOL success;
+
+  // Set up our STDIN, STDOUT, and STDERR
+  setup_file_handles(input, output, error,
+      &stdin_read, &stdin_write,
+      &stdout_read, &stdout_write,
+      &stderr_read, &stderr_write
+  );
+
+  // Now that we have our handles, set up STARTUPINFO so that the child process will use them
+  ZeroMemory(&start_info, sizeof(STARTUPINFO));
+  start_info.cb = sizeof(STARTUPINFO);
+  start_info.hStdInput  = stdin_read;
+  start_info.hStdOutput = stdout_write;
+  start_info.hStdError  = stderr_write;
+  start_info.dwFlags |= STARTF_USESTDHANDLES;
+
+  // Zero out our process information in ancipication of CreateProcess
+  // populating it, and then launch our process.
+  ZeroMemory(&proc_info, sizeof(PROCESS_INFORMATION));
+  success = CreateProcess(
+      /* lpApplicationName    */ NULL,
+      /* lpCommandLine        */ (LPSTR)command_line,
+      /* lpProcessAttributes  */ NULL,
+      /* lpThreadAttributes   */ NULL,
+      /* bInheritHandles      */ TRUE,
+      /* dwCreationFlags      */ 0,
+      /* lpEnvironment        */ NULL,
+      /* lpCurrentDirectory   */ NULL,
+      /* lpStartupInfo        */ &start_info,
+      /* lpProcessInformation */ &proc_info);
+
+  if (success) {
+    // Populate process with the relevant info
+    process->pid = (stz_long)proc_info.dwProcessId;
+    process->pipeid = -1; // -1 signals we didn't create named pipes for this process
+    process->in  = file_from_handle(stdin_write, FT_WRITE);
+    process->out = file_from_handle(stdout_read, FT_READ);
+    process->err = file_from_handle(stderr_read, FT_READ);
+
+    // Close the handles we passed into the child process
+    if (stdin_read   != NULL) CloseHandle(stdin_read);
+    if (stdout_write != NULL) CloseHandle(stdout_write);
+    if (stderr_write != NULL) CloseHandle(stderr_write);
+
+    // Close these left-over handles to the process
+    CloseHandle(proc_info.hThread);
+    CloseHandle(proc_info.hProcess);
+  }
+
+  return success ? 0 : -1;
+}

--- a/runtime/process.h
+++ b/runtime/process.h
@@ -1,0 +1,34 @@
+#ifndef RUNTIME_PROCESS_H
+#define RUNTIME_PROCESS_H
+
+#include <stdio.h>
+
+#include "types.h"
+
+typedef struct {
+  stz_long pid;
+  stz_int pipeid;
+  FILE* in;
+  FILE* out;
+  FILE* err;
+} Process;
+
+typedef struct {
+  stz_int state;
+  stz_int code;
+} ProcessState;
+
+#define PROCESS_RUNNING 0
+#define PROCESS_DONE 1
+#define PROCESS_TERMINATED 2
+#define PROCESS_STOPPED 3
+
+#define STANDARD_IN 0
+#define STANDARD_OUT 1
+#define PROCESS_IN 2
+#define PROCESS_OUT 3
+#define STANDARD_ERR 4
+#define PROCESS_ERR 5
+#define NUM_STREAM_SPECS 6
+
+#endif


### PR DESCRIPTION
This implements the process library on Windows using the `CreateProcess` function and friends.

This implementation diverges from the original POSIX implementation in that there is no dedicated launcher process. This is due to a lack of the use of (and support for) `fork()`. However, almost all of the semantics of the original are honored.

One caveat is that the first element of the argument list passed to the `Process()` constructor is ignored in favor of the `filename` argument denoting the executable. This was done to mirror the POSIX API where `argv[0]` is merely conventional. It was also done out of necessity because the Windows API requires a command-line to be passed (executable + arguments concatenated) rather than an executable and a list of arguments (like POSIX)

NOTE: This PR relies on #96 in order to compile.