### PR TITLE
Windows API error handling

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -2805,6 +2805,12 @@ protected lostanza defn linux-error-msg () -> ref<String> :
   val s = call-c clib/strerror(call-c clib/get_errno())
   return String(s)
 
+#if-defined(PLATFORM-WINDOWS):
+  extern get_windows_api_error: () -> ptr<byte>
+
+  protected lostanza defn windows-error-msg () -> ref<String> :
+    return String(call-c get_windows_api_error())
+
 ;============================================================
 ;====================== ToString ============================
 ;============================================================

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -30,6 +30,28 @@ static void init_fmalloc ();
 void* stz_malloc (stz_long size);
 void stz_free (void* ptr);
 
+#ifdef PLATFORM_WINDOWS
+char* get_windows_api_error() {
+  char* lpMsgBuf;
+  char* ret;
+
+  FormatMessage(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER |
+      FORMAT_MESSAGE_FROM_SYSTEM |
+      FORMAT_MESSAGE_IGNORE_INSERTS,
+      NULL,
+      GetLastError(),
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (char*)&lpMsgBuf,
+      0, NULL );
+
+  ret = strdup(lpMsgBuf);
+  LocalFree(lpMsgBuf);
+
+  return ret;
+}
+#endif
+
 //     Stanza Defined Entities
 //     =======================
 typedef struct{

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -52,6 +52,22 @@ char* get_windows_api_error() {
 }
 #endif
 
+#ifdef PLATFORM_WINDOWS
+static void exit_with_error_line_and_func (const char* file, int line) {
+  fprintf(stderr, "[%s:%d] %s", file, line, get_windows_api_error());
+  exit(-1);
+}
+#endif
+
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_OSX)
+static void exit_with_error_line_and_func (const char* file, int line){
+  fprintf(stderr, "[%s:%d] %s\n", file, line, strerror(errno));
+  exit(-1);
+}
+#endif
+
+#define exit_with_error() exit_with_error_line_and_func(__FILE__, __LINE__)
+
 //     Stanza Defined Entities
 //     =======================
 typedef struct{
@@ -495,11 +511,6 @@ typedef struct {
 //------------------------------------------------------------
 //-------------------- Utilities -----------------------------
 //------------------------------------------------------------
-
-static void exit_with_error (){
-  fprintf(stderr, "%s\n", strerror(errno));
-  exit(-1);
-}
 
 static int count_non_null (void** xs){
   int n=0;


### PR DESCRIPTION
This patch implements and improves error handling in Windows, by adding functions to get the last Windows API error, and by printing Windows API error messages when appropriate (instead of potentially-empty POSIX errors).

This is mostly scaffolding for later PRs, but it should be generally useful for any future work involving the Windows API.