### PR TITLE
Platform-specific error handling

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -2811,6 +2811,12 @@ protected lostanza defn linux-error-msg () -> ref<String> :
   protected lostanza defn windows-error-msg () -> ref<String> :
     return String(call-c get_windows_api_error())
 
+protected lostanza defn platform-error-msg () -> ref<String> :
+  #if-defined(PLATFORM-WINDOWS):
+    return windows-error-msg()
+  #else:
+    return linux-error-msg()
+
 ;============================================================
 ;====================== ToString ============================
 ;============================================================


### PR DESCRIPTION
Introduce `platform-error-msg()`. This should be called in order to get the correct error message for the current platform (rather than calling `windows-error-msg()` or `linux-error-msg()` directly)