### PR TITLE
core: add `switch` to LoStanza.

### DIFF
--- a/compiler/stz-core-macros.stanza
+++ b/compiler/stz-core-macros.stanza
@@ -2341,6 +2341,32 @@ defsyntax core :
    defrule ls-stmt = ((?c:#ls-stmt ?cs:#ls-stmts!)) : qquote($begin ~ c ~@ cs)
    defrule ls-stmt = (()) : `($begin)
 
+   ;                    Switch
+   ;                    ======
+   defproduction ls-switch-clause! : [? ?]
+   defrule ls-switch-clause! = ((! else) ?v:#ls-exp! #:! ?body:#ls-stmt!) :
+      [v, body]
+   defrule ls-stmt = (switch(?form:#ls-exp!)#:! (
+                      ?cs:#ls-switch-clause! ...
+                      else #:! ?alt:#ls-stmt!)) :
+      val template = `(let : (val x = form, exp))
+      val x = gensym(`x)
+      parse-syntax[core + current-overlays / #ls-stmt](
+         fill-template(template, [
+            `x => x
+            `form => form
+            `exp => gen-switch-equal-exp(x, cs, alt)]))
+
+   defrule ls-stmt = (switch(?form:#ls-exp!)#:! (
+                      ?cs:#ls-switch-clause! ...)) :
+      val alt = qquote(core/fatal("No appropriate switch clause."))
+      val template = `(let : (val x = form, exp))
+      val x = gensym(`x)
+      parse-syntax[core + current-overlays / #ls-stmt](
+         fill-template(template, [
+            `x => x
+            `form => form
+            `exp => gen-switch-equal-exp(x, cs, alt)]))
 
    ;                    #if-defined/#if-not-defined
    ;                    ===========================


### PR DESCRIPTION
Implement the `switch(expr)` macro for LoStanza. This can be used just like the normal `switch(expr)` macro in HiStanza:

With an `else` block:

```stanza
switch(rand() % 10):
   0: call-c puts("Kaboom!")
   6: call-c puts("Ka BOOM!")
   else: call-c puts("Splish...")
```

Without an `else` block:

```stanza
switch(i):
    0: call-c puts("we're good!")
    1: call-c puts("still good!")
call-c puts("Must have been good, otherwise the switch would've failed!")
```

Mostly just copied the HiStanza `switch` implementation and then adjusted the productions as-necessary to fit the LoStanza conventions (e.g. `#ls-exp` instead of `#exp`). Also removed the `upcast-as core/Equalable` because obviously that doesn't work in LoStanza. Let me know if this can be improved, or if you see any glaring issues.