### PR TITLE
Implement LivenessTracker

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1207,8 +1207,7 @@ lostanza defn set-mark (p:ptr<?>, vms:ptr<VMState>) -> ref<False> :
   return false
 
 ;Marks the given heap pointer in the state's heap bitset.
-;Returns a non-zero value if the pointer was previously marked.
-;Returns zero if the pointer was not previously marked.
+;Returns 0L when the pointer was previously marked, otherwise 1L.
 lostanza defn test-and-set-mark (p:ptr<?>, vms:ptr<VMState>) -> long :
   val index = bit-index(p, vms)
   val address = bit-address(index, vms)
@@ -1216,7 +1215,7 @@ lostanza defn test-and-set-mark (p:ptr<?>, vms:ptr<VMState>) -> long :
 
   val old-value = [address]
   [address] = old-value | mask
-  return old-value & mask
+  return (old-value & mask) == 0
 
 ;Clears the mark for the given heap pointer in the state's heap's bitset.
 lostanza defn clear-mark (p:ptr<?>, vms:ptr<VMState>) -> ref<False> :
@@ -1414,7 +1413,7 @@ lostanza defn mark-and-push (ref:ptr<long>, vms:ptr<VMState>) -> ref<False> :
     ;Remove the tagbits to retrieve the object pointer.
     val p = (v - 1) as ptr<long>
     ;Mark the object, and test whether it has already previously been marked.
-    if test-and-set-mark(p, vms) == 0 :
+    if test-and-set-mark(p, vms) :
       ;If there is still space in the marking stack add the object to the
       ;marking stack, otherwise add it to the incomplete range.
       if marking-stack-full(vms) : extend-incomplete-range(p, vms)
@@ -1435,7 +1434,7 @@ lostanza defn mark-from-root (ref:ptr<long>, vms:ptr<VMState>) -> ref<False> :
     val p = (v - 1) as ptr<long>
     ;Mark the object, and continue marking the object graph if it
     ;has not previously been marked.
-    if test-and-set-mark(p, vms) == 0 :
+    if test-and-set-mark(p, vms) :
       continue-marking(p, vms)
   ;No meaningful return value
   return false
@@ -1555,6 +1554,50 @@ lostanza defn mark-reachable-objects (vms:ptr<VMState>) -> ref<False> :
   ;Iteratively call continue-marking on all pointers in the
   ;incomplete range until we're finished.
   complete-marking(vms)
+  ;No meaningful return value
+  return false
+
+lostanza defn new-collect-garbage (vms:ptr<VMState>) -> ref<False> :
+  mark-reachable-objects(vms)
+  scan-liveness-trackers(vms)
+  ;No meaningful return value
+  return false
+
+;============================================================
+;================== New LivenessTracker =====================
+;============================================================
+
+public lostanza deftype NewLivenessTracker :
+  value: long   ;We don't want to mark through this field
+  tail: ptr<NewLivenessTracker>
+
+public lostanza defn NewLivenessTracker (value:ref<Unique>) -> ref<NewLivenessTracker> :
+  val tracker = new NewLivenessTracker{value as long, LIVENESS-TRACKERS}
+  LIVENESS-TRACKERS = tracker as ptr<NewLivenessTracker>
+  return tracker
+
+public lostanza defn value (t:ref<NewLivenessTracker>) -> ref<False|Unique> :
+  return t.value as ref<False|Unique>
+
+;Global list of live LivenessTrackers
+lostanza var LIVENESS-TRACKERS:ptr<NewLivenessTracker> = null
+
+lostanza defn scan-liveness-trackers (vms:ptr<VMState>) -> ref<False> :
+  var p:ptr<ptr<NewLivenessTracker>> = addr(LIVENESS-TRACKERS)
+  while [p] != null :
+    val tracker = [p]
+    if test-mark(tracker, vms) == 0 :
+      ;Unlink current tracker from the list
+      [p] = tracker.tail
+    else :
+      val value = tracker.value
+      if ((value & 7L) == 1L) and (test-mark((value - 1) as ptr<?>, vms) == 0) :
+        ;Replace the value with false-marker
+        [addr!(tracker.value)] = false-marker()
+        ;Unlink current tracker from the list
+        [p] = tracker.tail
+      else :
+        p = addr(tracker.tail)
   ;No meaningful return value
   return false
 


### PR DESCRIPTION
LivenessTrackers have to be reimplemented, otherwse all LivenessTrackers are reachable from LIVENESS-HANDLERS, and so are the references.