### PR TITLE
gitignore: ignore Vim swapfiles, build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,16 @@
 bin
 pkgs
 lpkgs
+wpkgs
 .#*
 *.*~
+*.swp
+*.swo
+
+build
+*.s
+*.pkg
+*.fpkg
+*.o
+*.exe
+stanza.aux


### PR DESCRIPTION
As stated in the title, ignore Vim swap files and any artifacts that may have been created during a build. Since we don't perform an out-of-tree build, this is doubly important for making `git status -u` behave somewhat sanely.