### PR TITLE
Create an `EXPORTS` table for `extern defn` symbols on Windows

### DIFF
--- a/compiler/stz-asm-emitter.stanza
+++ b/compiler/stz-asm-emitter.stanza
@@ -710,7 +710,7 @@ defn gen (ins:Ins, backend:Backend) :
       (ins:DefLong) : #println("   .quad %_" % [value(ins)])
       (ins:DefFloat) : #println("   .long %_" % [bits(value(ins))])
       (ins:DefDouble) : #println("   .quad %_" % [bits(value(ins))])
-      (ins:DefString) : println("   .byte %," % [chars(value(ins))])
+      (ins:DefString) : println("   .asciz %~" % [value(ins)])
       (ins:DefBytes) : println("   .byte %," % [value(ins)])
       (ins:DefSpace) : #println("   .space %_" % [size(ins)]) when size(ins) > 0
       (ins:DefLabel) : #println("   .quad %_" % [#lbl(n(ins))])

--- a/compiler/stz-asm-emitter.stanza
+++ b/compiler/stz-asm-emitter.stanza
@@ -255,7 +255,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
          else : RE()
       (ins:Label|ExLabel) :
          false
-      (ins:DefData|DefText|DefByte|DefInt|DefLong|
+      (ins:DefData|DefText|DefByte|DefInt|DefLong|DefSection|
            DefFloat|DefDouble|DefString|DefBytes|DefSpace|DefLabel) :
          false      
 
@@ -716,6 +716,7 @@ defn gen (ins:Ins, backend:Backend) :
       (ins:DefLabel) : #println("   .quad %_" % [#lbl(n(ins))])
       (ins:DefData) : println("   .data")
       (ins:DefText) : println("   .text")
+      (ins:DefSection) : println("   .section %_" % [name(ins)])
 
 ;============================================================
 ;===================== Driver ===============================

--- a/compiler/stz-asm-ir.stanza
+++ b/compiler/stz-asm-ir.stanza
@@ -189,6 +189,7 @@ public defast :
     ;==== Data Instructions ====
     DefData
     DefText
+    DefSection : (name:String)
     DefByte : (value:Byte)
     DefInt : (value:Int)
     DefLong : (value:Long)
@@ -323,6 +324,7 @@ defmethod print (o:OutputStream, i:Ins) :
     (i:MethodDispatch) : "  method-dispatch(%_) no: %_ amb: %_" % [multi(i), no-branch(i), amb-branch(i)]
     (i:DefData) : "   .data"
     (i:DefText) : "   .text"
+    (i:DefSection) : "   .section %_" % [name(i)]
     (i:DefByte) : "   .byte %~" % [value(i)]
     (i:DefInt) : "   .int %~" % [value(i)]
     (i:DefLong) : "   .long %~" % [value(i)]

--- a/compiler/stz-pkg.stanza
+++ b/compiler/stz-pkg.stanza
@@ -15,7 +15,7 @@ defpackage stz/pkg :
            UltOp, UgtOp, UgeOp, NotOp, NegOp, DivModOp, BitSetOp, BitNotSetOp,
            TypeofOp, XchgIns, SetIns, ConvertIns, InterpretIns, UnaOp, BinOp,
            DualOp, Load, Store, Call, Return, Goto, Break, Label, LinkLabel,
-           ExLabel, Match, Dispatch, MethodDispatch, DefData, DefText, DefByte,
+           ExLabel, Match, Dispatch, MethodDispatch, DefData, DefText, DefSection, DefByte,
            DefInt, DefLong, DefFloat, DefDouble, DefString, DefBytes, DefSpace, DefLabel) => asm-
   import stz/visibility
   import stz/dl-ir
@@ -875,6 +875,7 @@ defserializer (out:FileOutputStream, in:FileInputStream) :
     asm-MethodDispatch: (multi:int, num-header-args:int, no-branch:imm, amb-branch:imm)
     asm-DefData: ()
     asm-DefText: ()
+    asm-DefSection: (name:string)
     asm-DefByte: (value:byte)
     asm-DefInt: (value:int)
     asm-DefLong: (value:long)

--- a/compiler/stz-stitcher.stanza
+++ b/compiler/stz-stitcher.stanza
@@ -1010,6 +1010,7 @@ defstruct ClassProps <: GProps :
 ;============================================================
 
 public defn emit-stubs (s:Stitcher, emitter:CodeEmitter) :
+  emit(emitter, DefText())
   compile-extend-stack-stub(s, emitter)
   compile-collect-garbage-stub(s, emitter)
   compile-c-trampoline-stub(backend(stubs(s)), emitter)

--- a/compiler/stz-stitcher.stanza
+++ b/compiler/stz-stitcher.stanza
@@ -941,6 +941,21 @@ public defn Stitcher (packages:Collection<VMPackage>, bindings:Bindings|False, s
       E $ StoreL(M(extern-table(stubs)), R1, 8 + 16 * i + 8)
     E $ Goto(R0)    
 
+  defn emit-export-table (code-emitter: CodeEmitter) -> False:
+    defn E (i:Ins) : emit(code-emitter, i)
+
+    ; First collect all of the `extern defn` symbols
+    val defns = to-tuple $ for package in packages seq-cat :
+      for def in extern-defns(package) seq:
+        lbl(def)
+
+    ; If we have any, mark that we're now in a .drectve section, and then for
+    ; each symbol, put out a string directing the assembler to export it
+    if length(defns) > 0:
+      E $ DefSection(".drectve")
+      for def in defns do :
+        E $ DefString $ to-string(" -export:\"%~\"" % [def])
+
   ;Initialize record tables
   initialize-record-tables()
   initialize-simple-props()
@@ -962,6 +977,10 @@ public defn Stitcher (packages:Collection<VMPackage>, bindings:Bindings|False, s
       emit-stackmap-table(code-emitter)
       emit-info-table(code-emitter)
       emit-extern-table(code-emitter)
+      #if-defined(PLATFORM-WINDOWS):
+        ; On Windows, create an EXPORTS table for `extern defn` symbols
+        ; so they can be dynamically imported by other executables
+        emit-export-table(code-emitter)
     defmethod stubs (this) :
       stubs
     defmethod core-fn (this, id:FnId) :

--- a/notes/emitter.txt
+++ b/notes/emitter.txt
@@ -21,6 +21,7 @@ Immediates :
 Data Instructions :
    DefData : Indicates the start of a data section
    DefText : Indicates the start of a text section
+   DefSection : Indicates the start of a section with a given name.
    DefByte : Defines a byte value.
    DefInt : Defines a int value.
    DefLong : Defines a long value.
@@ -453,3 +454,4 @@ Generating Value Definition :
    DefLabel : .quad name
    DefData : .data
    DefText : .text
+   DefSection : .section name

--- a/notes/emitter.txt
+++ b/notes/emitter.txt
@@ -449,7 +449,7 @@ Generating Value Definition :
    DefByte : .byte value
    DefInt : .long value
    DefLong : .quad value
-   DefString : .byte char1 char2 char3 ... 0
+   DefString : .asciz "value"
    DefSpace : .space size
    DefLabel : .quad name
    DefData : .data


### PR DESCRIPTION
On Windows, in order to import a symbol from a DLL (or executable), it is necessary that that symbol be exported from the original binary. This is done by the assembler placing an export directive in the EXPORTS section of the created binary. The presence of this table and its contents can be observed using `dumpbin.exe /EXPORTS <binary>` (available as part of the standard VS toolchain).

The purpose of `extern defn` is to create an externally referenceable symbol that can be linked to (or dynamically loaded) from C (or languages that support C's ABI). On Linux this is achieved automatically -- all global symbols are exported. However, as described above, on Windows the compiler must take care to manually export these symbols.

As such, when there are `extern defn` symbols present in a compiled collection of packages, we now generate an EXPORTS table containing an entry for each symbol. To achieve this using GAS (our assembler), we generate a `.section drectve` and for each symbol generate an ASCII string containing the export directive (` .asciz " -export:\"<symbol>\""`). This section should never be empty (i.e. we only generate it when there are `extern defn` symbols to export). This allows these symbols to be properly linked to and be dynamically loaded.

This necessitated one seemingly-unrelated change: previously we assumed before emitting stubs (`emit-stubs` in `stz/compiler-main`) that we were already in a `.text` section. Since the EXPORTS table is generated before we emit stubs (at the end of the rest of the tables emitted by `emit-tables`), and it changes the section to `drectve`, the generation of this table would cause the subsequently-generated stubs to be interpreted as part of the `drectve` section (and not in `.text`). This resulted in a malformed executable. In order to fix the issue, we now unconditionally emit a `.text` directive before emitting the stubs (since this will always produce the correct output, and removes an ordering dependency on the behavior of `emit-tables`)