### PR TITLE
parsed-path: allow `<drive>:/` in Windows paths.

### DIFF
--- a/core/parsed-path.stanza
+++ b/core/parsed-path.stanza
@@ -180,7 +180,7 @@ defmethod parse-path (path:String, platform:Windows) -> ParsedPath :
   ;Parse the beginning drive letter.
   defn* parse-drive-letter? () :
     if path-char(1) == ':' :
-      if path-char(2) != '\\' :
+      if path-char(2) != '\\' and path-char(2) != '/' :
         throw(IllegalDriveSpecifier(path))
       val c = path-char(0) as Char
       if not letter?(c) :


### PR DESCRIPTION
On Windows, paths can be given with either forward or back-slashes (and sometimes even a mix of the two.) The path parser understands this in every position, except when checking the drive specifier -- here, it assumes the drive specifier must be of the form `<drive>:\`. This is incorrect, `<drive>:/` is also completely acceptable. This causes issues when these paths are given to Stanza (e.g. via `$STANZA_CONFIG`)

To fix, simply allow `/` as well as `\` when validating the drive specifier.

Fixes #124 