### PR TITLE
Ponter relocation

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1786,16 +1786,14 @@ lostanza defn create-break-table (compaction-start:ptr<long>, vms:ptr<VMState>) 
       vms.new-heap.top = current-unmarked
       return false
     val next-unmarked = skip-and-clear-marked(next-marked, vms)
-
     ;Store the live range information in the heap in the
     ;current break.
     write-live-range(current-unmarked, LiveRange{next-marked, next-unmarked})
 
     ;Compute the length of the current break, and update the
     ;accumulated offset.
-    val break-length = next-marked - current-unmarked
-    offset = offset - break-length
-    
+    offset = offset - (next-marked - current-unmarked)
+
     ;Fill break table root entries.
     ;The upcoming live range can potentially span multiple buckets.
     ;Compute 'start-index' and 'end-index' the indices of the first
@@ -1821,7 +1819,47 @@ lostanza defn create-break-table (compaction-start:ptr<long>, vms:ptr<VMState>) 
       
     ;Advance past the live range to the next potential break.
     current-unmarked = next-unmarked
+  ;No meaningful return value
+  return false
 
+lostanza defn relocation-offset (p:ptr<?>, vms:ptr<VMState>) -> long :
+  val break-table = vms.new-heap.stack-start as ptr<BreakTableEntry>
+  val break-table-entry = break-table[break-table-index(p, vms)]
+  var offset:long = break-table-entry.accumulated-offset
+  var dead:ptr<long> = break-table-entry.first-break-location
+  while dead < p :
+    val next = read-live-range(dead)
+    offset = offset - (next.live - dead)
+    dead = next.dead
+  return offset
+
+lostanza defn relocate-reference (ref:ptr<long>, vms:ptr<VMState>) -> ref<False> :
+  ;Retrieve the value at the given heap pointer.
+  val v = [ref]
+  ;Is this a reference to a Stanza heap object?
+  val tagbits = v & 7L
+  if tagbits == 1L :
+    ;Remove the tag bits to retrieve the object pointer.
+    val p = (v - 1) as ptr<long>  ;This decrement is not really necessary
+    if p > vms.new-heap.compaction-start :
+      [ref] = v + relocation-offset(p, vms)
+  ;No meaningful return value
+  return false
+
+lostanza defn relocate-references (vms:ptr<VMState>) -> ref<False> :
+  iterate-roots(addr(relocate-reference), vms)
+  relocate-liveness-trackers(vms)
+  ;Scan the live ranges
+  val limit = vms.new-heap.top
+  var dead:ptr<long> = vms.new-heap.compaction-start
+  while dead < limit :
+    val next = read-live-range(dead)
+    ;Relocate references in every object in the live range
+    var p:ptr<long> = next.live
+    while p < next.dead :
+      iterate-references(p, addr(relocate-reference), vms)
+      p = p + allocation-size(p, vms)
+    dead = next.dead
   ;No meaningful return value
   return false
 
@@ -1835,7 +1873,7 @@ lostanza defn new-collect-garbage (vms:ptr<VMState>) -> ref<False> :
   val compaction-start = skip-and-clear-marked(vms.new-heap.start, vms)
   if compaction-start < vms.new-heap.top :
     create-break-table(compaction-start, vms)
-    
+    relocate-references(vms)
   ;No meaningful return value
   return false
 
@@ -1879,6 +1917,7 @@ lostanza defn scan-liveness-trackers (vms:ptr<VMState>) -> ref<False> :
   ;p is a pointer to the list being scanned.
   var p:ptr<ptr<NewLivenessTracker>> = addr(LIVENESS-TRACKERS)
   ;Scan until we reach the end of the list (represented using null pointer).
+  ;TODO: In generational GC scan the list while [p] >= collection-area-start
   while [p] != null :
     ;Retrieve the next ptr<LivenessTracker> in the list.
     val tracker = [p]
@@ -1910,6 +1949,23 @@ lostanza defn scan-liveness-trackers (vms:ptr<VMState>) -> ref<False> :
         ;Go to the next element in the list.
         p = addr(tracker.tail)
 
+  ;No meaningful return value
+  return false
+
+lostanza defn relocate-liveness-trackers (vms:ptr<VMState>) -> ref<False> :
+  val compaction-start = vms.new-heap.compaction-start
+  ;p is a pointer to the list being scanned.
+  var p:ptr<ptr<NewLivenessTracker>> = addr(LIVENESS-TRACKERS)
+  ;GC preserves the allocation order, so tracker value is always below the tracker
+  while [p] > compaction-start :
+    ;Retrieve the next ptr<LivenessTracker> in the list.
+    val tracker = [p]
+    ;Relocate the pointer to the tracker
+    [p] = tracker + relocation-offset(tracker, vms)
+    ;Relocate the tracker value
+    relocate-reference(addr(tracker.value), vms)
+    ;Go to the next element in the list.
+    p = addr(tracker.tail)
   ;No meaningful return value
   return false
 


### PR DESCRIPTION
Relocate pointers according to the created break table.

LivenessTrackers have to be relocated separately because of the tricks to avoid their marking. 