### PR TITLE
Compact data according to the created break table

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1876,7 +1876,7 @@ lostanza defn create-break-table (compaction-start:ptr<long>, vms:ptr<VMState>) 
 
 ;Returns the offset that needs to be added to an object to
 ;compute its new address after compaction.
-;- p: The pointer to the object header.
+;- p: The pointer to the object header, inside the object or rigth above the object.
 lostanza defn relocation-offset (p:ptr<?>, vms:ptr<VMState>) -> long :
   ;Retrieve the break table from the memory originally used for the
   ;marking stack.
@@ -1915,8 +1915,7 @@ lostanza defn relocate-reference (ref:ptr<long>, vms:ptr<VMState>) -> ref<False>
   if tagbits == 1L :
     ;Remove the tag bits to retrieve the object pointer.
     val p = (v - 1) as ptr<long>  ;This decrement is not really necessary
-    ;Check explicitly whether the pointer is in the compaction area because
-    ;relocation-offset is only designed to work if that holds.
+    ;Only pointers to objects in the compaction area are relocated.
     if p > vms.new-heap.compaction-start :
       [ref] = v + relocation-offset(p, vms)
   ;No meaningful return value
@@ -1946,7 +1945,34 @@ lostanza defn relocate-references (vms:ptr<VMState>) -> ref<False> :
   ;No meaningful return value
   return false
 
+lostanza defn compact (vms:ptr<VMState>) -> ref<False> :
+  var offset:long = 0
+  val top = vms.new-heap.top
+  var dead:ptr<long> = vms.new-heap.compaction-start
+  while dead < top :
+    val next = read-live-range(dead)
+    offset = offset - (next.live - dead)
+    call-c clib/memcpy(next.live + offset, next.live, next.dead - next.live)
+    dead = next.dead
+  vms.new-heap.top = top + offset
+  ;No meaningful return value
+  return false
+
+lostanza defn fatal-object-marked! (p:ptr<long>, vms:ptr<VMState>) -> ref<False> :
+  fatal("Unexpected marked object.")
+  ;No meaningful return value
+  return false
+
+lostanza defn ensure-no-marks-in-collection-area! (vms:ptr<VMState>) -> ref<False> :
+  #if-not-defined(OPTIMIZE) :
+    ;There must be no marks in collection area and above heap top
+    iterate-marked(vms.new-heap.start, vms.new-heap.limit, addr(fatal-object-marked!), vms)
+  ;No meaningful return value
+  return false
+
 lostanza defn new-collect-garbage (vms:ptr<VMState>) -> ref<False> :
+  ensure-no-marks-in-collection-area!(vms)
+
   mark-reachable-objects(vms)
   scan-liveness-trackers(vms)
 
@@ -1957,6 +1983,9 @@ lostanza defn new-collect-garbage (vms:ptr<VMState>) -> ref<False> :
   if compaction-start < vms.new-heap.top :
     create-break-table(compaction-start, vms)
     relocate-references(vms)
+    compact(vms)
+
+  ensure-no-marks-in-collection-area!(vms)
   ;No meaningful return value
   return false
 


### PR DESCRIPTION
Scan live ranges according to the break table, accumulate the offset, move the live range down according to the offset, adjust heap top according to the final offset. 