### PR TITLE
jb/tuple get

### DIFF
--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -2540,13 +2540,13 @@ defn box-unbox-fold (epackage:EPackage, gvt:VarTable) -> EPackage :
   ;Compute binding table.
   ;Every entry in the binding table, x => e, indicates that
   ;x is defined exactly once by the EObject or ENewObject instruction.
-  defn binding-table (e:EBody) -> IntTable<EObject|ENewObject> :
-    val table = IntListTable<EObject|ENewObject>()
+  defn binding-table (e:EBody) -> IntTable<ELItem> :
+    val table = IntListTable<ELItem>()
     val remove-set = IntSet()
     for i in ins(e) do :
-      match(i:EObject|ENewObject) : add(table, n(x(i)), i)
+      match(i:EObject|ENewObject|ETuple) : add(table, n(x(i)), i)
       else : do(add{remove-set, n(_)}, varlocs(i))
-    to-inttable<EObject|ENewObject> $
+    to-inttable<ELItem> $
       for entry in table seq? :
         if remove-set[key(entry)] : None()
         else if length(value(entry)) == 1 : One(key(entry) => head(value(entry)))
@@ -2563,7 +2563,7 @@ defn box-unbox-fold (epackage:EPackage, gvt:VarTable) -> EPackage :
   ;field. Calls fail() if not a match.
   defn unbox-object-get (e:EObjectGet,
                          vt:VarTable,
-                         bindings:IntTable<EObject|ENewObject>) -> [EVarLoc, EImm] :
+                         bindings:IntTable<ELItem>) -> [EVarLoc, EImm] :
     val v = y(e) as? EVar
     val o = get?(bindings, n(v)) as? ENewObject
     val value = ys(o)[index(e)]
@@ -2575,13 +2575,25 @@ defn box-unbox-fold (epackage:EPackage, gvt:VarTable) -> EPackage :
   ;Calls fail() if not a match.
   defn unbox-load (e:ELoad,
                    vt:VarTable,
-                   bindings:IntTable<EObject|ENewObject>, ) -> [EVarLoc, EImm] :
+                   bindings:IntTable<ELItem>, ) -> [EVarLoc, EImm] :
     val field = loc(e) as? EField
     val v = y(loc(field) as? EDeref) as? EVar
     val o = get?(bindings, n(v)) as? EObject
     fail() when mutable-field?(defstruct-table, n(o), index(field))
     val value = ys(o)[index(field)]
     fail() when not immutable?(vt,value)      
+    [x(e), value]
+
+  ;If the given ETupleGet expression corresponds to a retrieval
+  ;of a tuple element of a known tuple then return the destination and the field.
+  ;Calls fail() if not a match.
+  defn unbox-tuple-get (e:ETupleGet,
+                        vt:VarTable,
+                        bindings:IntTable<ELItem>, ) -> [EVarLoc, EImm] :
+    val v = y(e) as? EVar
+    val t = get?(bindings, n(v)) as? ETuple
+    val value = ys(t)[index(e)]
+    println("--- TUPLE GET OPT %_ OF %_ -> %_" % [e, t, value])
     [x(e), value]
 
   ;Perform unboxing folds in the given body.
@@ -2603,6 +2615,11 @@ defn box-unbox-fold (epackage:EPackage, gvt:VarTable) -> EPackage :
             val [x, v] = unbox-load(i, vt, bindings)
             EDef(x, v, false)
           else : i
+        (i:ETupleGet) :
+          attempt :
+            val [x, v] = unbox-tuple-get(i, vt, bindings)
+            EDef(x, v, false)
+          else : i            
         (i) : i
 
     ;Attempt to fold all instructions.

--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -2593,7 +2593,6 @@ defn box-unbox-fold (epackage:EPackage, gvt:VarTable) -> EPackage :
     val v = y(e) as? EVar
     val t = get?(bindings, n(v)) as? ETuple
     val value = ys(t)[index(e)]
-    println("--- TUPLE GET OPT %_ OF %_ -> %_" % [e, t, value])
     [x(e), value]
 
   ;Perform unboxing folds in the given body.


### PR DESCRIPTION
Add another box-unbox optimization for tuple/tuple-get.  This allows tuple gets to be performed at compile time when corresponding tuples are locally constructed.