### PR TITLE
Add `stanza/platform.h` and use it to export Stanza's `main` function

### DIFF
--- a/include/stanza.h
+++ b/include/stanza.h
@@ -1,6 +1,7 @@
 #ifndef STANZA_STANZA_H
 #define STANZA_STANZA_H
 
+#include "stanza/platform.h"
 #include "stanza/types.h"
 
 #endif

--- a/include/stanza/platform.h
+++ b/include/stanza/platform.h
@@ -1,0 +1,12 @@
+#ifndef STANZA_PLATFORM_H
+#define STANZA_PLATFORM_H
+
+#ifdef PLATFORM_WINDOWS
+#define STANZA_EXPORTED_SYMBOL __declspec(dllexport)
+#else
+#define STANZA_EXPORTED_SYMBOL
+#endif
+
+#define STANZA_API_FUNC STANZA_EXPORTED_SYMBOL
+
+#endif

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -25,6 +25,7 @@
 #include<dirent.h>
 #include<pthread.h>
 
+#include <stanza/platform.h>
 #include <stanza/types.h>
 
 #include "process.h"
@@ -1178,7 +1179,7 @@ static uint64_t alloc_stack (VMInit* init){
   return (uint64_t)stack - 8 + 1;  
 }
 
-int main (int argc, char* argv[]) {
+STANZA_API_FUNC int main (int argc, char* argv[]) {
   #if defined(FMALLOC)
     init_fmalloc();
   #endif


### PR DESCRIPTION
Add a header to `stanza.h` called `stanza/platform.h` that contains the defines necessary to properly export Stanza symbols in the runtime. It currently contains two macros:

- `STANZA_EXPORTED_SYMBOL`
  This marks the following declaration for export (`__declspec(dllexport)`) on Windows, which is necessary for the
  symbol to be loaded dynamically.

- `STANZA_API_FUNC`
  Just an alias for `STANZA_EXPORTED_SYMBOL` for now, but separate to emphasize that this is the Stanza API for functions.

  This macro is also employed to allow future use of a standard trick where we use this same define to *import* the symbol, when the symbol is defined in a header that gets consumed by a downstream dependency. Currently we don't actually use this in any headers, and so this particular patch doesn't add the IMPORT side of things, but this setup allows us to support it seamlessly in the future.

  For an example of how this mirrors previous art see the `cpython` or `lua` sources (specifically `pyport.h` and `luaconf.h`)

Additionally, use `STANZA_API_FUNC` to properly export the `main` function in the Stanza runtime, so that it can be imported to initialize a dynamically-loaded Stanza library or executable.