### PR TITLE
build: link statically on Windows

### DIFF
--- a/scripts/wfinish.sh
+++ b/scripts/wfinish.sh
@@ -25,4 +25,4 @@ CCFLAGS="-I include -DPLATFORM_WINDOWS -std=gnu99 -O3 -fPIC -Wall $CCFLAGS"
     build/cvm.o       \
     build/driver.o    \
     wstanza.s         \
-    -o wstanza -lm -lpthread -fPIC
+    -o wstanza -Wl,-Bstatic -lm -lpthread -fPIC


### PR DESCRIPTION
On Windows, link libraries (like `-lpthread`) statically so that the resulting executable does not require any DLLs at runtime. This is necessary on Windows due to a dependency on `libwinpthread-1.dll` that results in the compiled executable when linking dynamically. Linking statically avoids having to ship `libwinpthread-1.dll` and is generally preferable unless we have a good reason to link dynamically.

Fixes #133