### PR TITLE
Allow specifying the working directory of a `core/Process`

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -77,9 +77,11 @@ protected extern stz_memory_resize: (ptr<?>, long, long) -> int
 
 ;Process libraries
 #if-defined(PLATFORM-WINDOWS):
-  protected extern launch_process: (ptr<byte>, int, int, int, ptr<?>) -> int
+  protected extern launch_process:
+    (ptr<byte>, int, int, int, ptr<byte>, ptr<?>) -> int
 #else:
-  protected extern launch_process: (ptr<byte>, ptr<ptr<byte>>, int, int, int, int, ptr<?>) -> int
+  protected extern launch_process:
+    (ptr<byte>, ptr<ptr<byte>>, int, int, int, int, ptr<byte>, ptr<?>) -> int
   protected extern delete_process_pipes: (ptr<?>, ptr<?>, ptr<?>, int) -> int
   protected extern initialize_launcher_process: () -> int
 protected extern retrieve_process_state: (long, ptr<?>, int) -> int
@@ -8852,7 +8854,8 @@ defn SystemCallException (msg:String) :
                                 args0:ref<Seqable<String>>,
                                 input:ref<StreamSpecifier>,
                                 output:ref<StreamSpecifier>,
-                                error:ref<StreamSpecifier>) -> ref<Process> :
+                                error:ref<StreamSpecifier>,
+                                working-dir:ptr<byte>) -> ref<Process> :
     val proc = new Process{0, -1, null, null, null, false, false, false}
 
     ; Create a command line from the given filename and args (discarding the first argument).
@@ -8867,7 +8870,7 @@ defn SystemCallException (msg:String) :
     val output_v = value(output).value
     val error_v = value(error).value
     val launch_success = call-c clib/launch_process(
-      addr!(command-line.chars), input_v, output_v, error_v, addr!([proc]))
+      addr!(command-line.chars), input_v, output_v, error_v, working-dir, addr!([proc]))
     if launch_success != 0 :
       throw(SystemCallException(windows-error-msg()))
     return proc
@@ -8876,7 +8879,8 @@ defn SystemCallException (msg:String) :
                                 args0:ref<Seqable<String>>,
                                 input:ref<StreamSpecifier>,
                                 output:ref<StreamSpecifier>,
-                                error:ref<StreamSpecifier>) -> ref<Process> :
+                                error:ref<StreamSpecifier>,
+                                working-dir:ptr<byte>) -> ref<Process> :
     ensure-valid-stream-specifiers(input, output, error)
     val args = to-tuple(args0)
     val pipe-id = next-int(PIPE-ID-GENERATOR).value
@@ -8890,10 +8894,35 @@ defn SystemCallException (msg:String) :
     for (var i:long = 0, i < nargs, i = i + 1) :
       argvs[i] = addr!(args.items[i].chars)
     val launch_succ = call-c clib/launch_process(addr!(filename.chars), argvs,
-      input_v, output_v, error_v, proc.pipeid, addr!([proc]))
+      input_v, output_v, error_v, proc.pipeid, working-dir, addr!([proc]))
     if launch_succ != 0 :
       throw(SystemCallException(linux-error-msg()))
     return proc
+
+public lostanza defn Process (filename:ref<String>,
+                              args:ref<Seqable<String>>,
+                              input:ref<StreamSpecifier>,
+                              output:ref<StreamSpecifier>,
+                              error:ref<StreamSpecifier>,
+                              working-dir:ref<String>) -> ref<Process> :
+  return Process(filename,
+                 args,
+                 input,
+                 output,
+                 error,
+                 addr!(working-dir.chars))
+
+public lostanza defn Process (filename:ref<String>,
+                              args:ref<Seqable<String>>,
+                              input:ref<StreamSpecifier>,
+                              output:ref<StreamSpecifier>,
+                              error:ref<StreamSpecifier>) -> ref<Process> :
+  return Process(filename,
+                 args,
+                 input,
+                 output,
+                 error,
+                 null)
 
 public defn Process (filename:String, args:Seqable<String>) :
   Process(filename, args, STANDARD-IN, STANDARD-OUT, STANDARD-ERR)

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -705,6 +705,7 @@ typedef struct {
   stz_byte* out_pipe;
   stz_byte* err_pipe;
   stz_byte* file;
+  stz_byte* working_dir;
   stz_byte** argvs;
 } EvalArg;
 
@@ -776,6 +777,7 @@ static void write_earg (FILE* f, EvalArg* earg){
   write_string(f, earg->out_pipe);
   write_string(f, earg->err_pipe);
   write_string(f, earg->file);
+  write_string(f, earg->working_dir);
   write_strings(f, earg->argvs);
 }
 static void write_process_state (FILE* f, ProcessState* s){
@@ -833,6 +835,7 @@ static EvalArg* read_earg (FILE* f){
   earg->out_pipe = read_string(f);
   earg->err_pipe = read_string(f);
   earg->file = read_string(f);
+  earg->working_dir = read_string(f);
   earg->argvs = read_strings(f);
   return earg;
 }
@@ -954,6 +957,12 @@ static void launcher_main (FILE* lin, FILE* lout){
           if(fd < 0) write_error_and_exit(exec_error[WRITE]);
           dup2(fd, 2);
         }
+
+        if (earg->working_dir) {
+          if (chdir(C_CSTR(earg->working_dir)) == -1) {
+            write_error_and_exit(exec_error[WRITE]);
+          }
+        }
         
         //Launch child process      
         execvp(C_CSTR(earg->file), (char**)earg->argvs);
@@ -1050,7 +1059,7 @@ stz_int delete_process_pipes (FILE* input, FILE* output, FILE* error, stz_int pi
 
 stz_int launch_process(stz_byte* file, stz_byte** argvs, stz_int input,
                        stz_int output, stz_int error, stz_int pipeid,
-                       Process* process) {
+                       stz_byte* working_dir, Process* process) {
   //Initialize launcher if necessary
   initialize_launcher_process();
   
@@ -1075,7 +1084,7 @@ stz_int launch_process(stz_byte* file, stz_byte** argvs, stz_int input,
     RETURN_NEG(make_pipe(pipe_name, "_err"))
   
   //Write in command and evaluation arguments
-  EvalArg earg = {STZ_STR(pipe_name), NULL, NULL, NULL, file, argvs};
+  EvalArg earg = {STZ_STR(pipe_name), NULL, NULL, NULL, file, working_dir, argvs};
   if(input == PROCESS_IN) earg.in_pipe = STZ_STR("_in");
   if(output == PROCESS_OUT) earg.out_pipe = STZ_STR("_out");
   if(output == PROCESS_ERR) earg.out_pipe = STZ_STR("_err");

--- a/runtime/process-win32.c
+++ b/runtime/process-win32.c
@@ -207,7 +207,11 @@ static void setup_file_handles(
   if (stderr_write != NULL) CloseHandle(stderr_write);
 }
 
-stz_int launch_process(stz_byte* command_line, stz_int input, stz_int output, stz_int error, Process* process) {
+stz_int launch_process(
+    stz_byte* command_line,
+    stz_int input, stz_int output, stz_int error,
+    stz_byte* working_dir, Process* process) {
+
   PROCESS_INFORMATION proc_info;
   STARTUPINFO start_info;
   HANDLE stdin_read, stdin_write,
@@ -241,7 +245,7 @@ stz_int launch_process(stz_byte* command_line, stz_int input, stz_int output, st
       /* bInheritHandles      */ TRUE,
       /* dwCreationFlags      */ 0,
       /* lpEnvironment        */ NULL,
-      /* lpCurrentDirectory   */ NULL,
+      /* lpCurrentDirectory   */ (LPSTR)working_dir,
       /* lpStartupInfo        */ &start_info,
       /* lpProcessInformation */ &proc_info);
 


### PR DESCRIPTION
This patch adds an additional (optional) parameter to `core/Process` so that the working directory of the spawned process can be specified. This is particularly useful for running executables that are sensitive to their working directory and don't allow you to specify it using some kind of flag.

This is made necessary on Linux in part due to how the launcher daemon works. The usual method of performing a `chdir()` in the parent process, and then calling `Process(...)` to spawn the child process will not work as expected, because spawned processes are actually children of the launcher daemon, and hence the `chdir()` in the parent (the launcher daemon's parent) does not propagate to the launched process.

As an added benefit, this new parameter slots nicely into a previously-unused argument to `CreateProcess` on Windows.