### PR TITLE
Remove global buffer

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -5091,31 +5091,25 @@ public defn qsort!<?T,?S> (key:T -> ?S&Comparable<S>, xs:IndexedCollection<?T>) 
 ;                        Non-Destructive Sorting
 ;                        =======================
 
-val SORT-BUFFER = Vector<?>()
-defn clear-sort-buffer () :
-  val ret = to-tuple(SORT-BUFFER)
-  clear(SORT-BUFFER)
-  ret
-
 public defn qsort<?T> (coll:Seqable<?T>, is-less?:(T,T) -> True|False) -> Tuple<T> :
-  add-all(SORT-BUFFER, coll)
-  qsort!(SORT-BUFFER, is-less?)
-  clear-sort-buffer()
+  val buffer = to-vector<?> $ coll
+  qsort!(buffer, is-less?)
+  to-tuple(buffer)
 
 public defn qsort<?T> (coll:Seqable<?T>, cmp:(T,T) -> Int) -> Tuple<T> :
-  add-all(SORT-BUFFER, coll)
-  qsort!(SORT-BUFFER, cmp)
-  clear-sort-buffer()
+  val buffer = to-vector<?> $ coll
+  qsort!(buffer, cmp)
+  to-tuple(buffer)
 
 public defn qsort<?T> (coll:Seqable<?T&Comparable<T>>) -> Tuple<T> :
-  add-all(SORT-BUFFER, coll)
-  qsort!(SORT-BUFFER)
-  clear-sort-buffer()
+  val buffer = to-vector<?> $ coll
+  qsort!(buffer)
+  to-tuple(buffer)
 
 public defn qsort<?T,?S> (key:T -> ?S&Comparable<S>, coll:Seqable<?T>) -> Tuple<T> :
-  add-all(SORT-BUFFER, coll)
-  qsort!(key as ? -> ?, SORT-BUFFER)
-  clear-sort-buffer()
+  val buffer = to-vector<?> $ coll
+  qsort!(key as ? -> ?, buffer)
+  to-tuple(buffer)
 
 ;                       Lazy Sorting
 ;                       ============


### PR DESCRIPTION
I got several errors on elements accumulating in `SORT-BUFFER` from different `qsort` calls, the last of which I have no idea why. So here is the fix.
The decision to have a global buffer is surprising in the first place.