### PR TITLE
Allow for indexing of `.stanza` source files in `definitions-database` command

### DIFF
--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -34,12 +34,14 @@ public defn defs-db (input:DefsDbInput, filename:String) :
     (f:False) : OUTPUT-PLATFORM
     
   ;Read all listed packages from given project files
-  val proj-file = read-proj-files(proj-files(input), db-platform)
+  val all-proj-files = filter(suffix?{_, ".proj"}, proj-files(input))
+  val proj-file      = read-proj-files(all-proj-files, db-platform)
   val input-packages = all-packages(proj-file)
 
   ;Construct build settings
   val proj-files-and-packages = to-tuple $
     cat(proj-files(input), input-packages)
+
   val build-settings = BuildSettings(
     BuildPackages(proj-files-and-packages), ;inputs
     [],                                     ;vm-packages

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -814,11 +814,11 @@ defn defs-db-command () :
 
   ;Verify arguments
   defn verify-args (cmd-args:CommandArgs) :
-    defn ensure-proj-file! (file:String) :
-      if not suffix?(file, ".proj") :
+    defn ensure-proj-or-source-file! (file:String) :
+      if not (suffix?(file, ".proj") or suffix?(file, ".stanza")):
         throw(ArgParseError("File %~ is not a valid file for building definitions database. \
-                             A project file (.proj) is expected." % [file]))                         
-    do(ensure-proj-file!, args(cmd-args))    
+                             A project file (.proj) or source file (.stanza) is expected." % [file]))                         
+    do(ensure-proj-or-source-file!, args(cmd-args))    
   
   ;Main action for command
   val defs-db-msg = "Generates the Stanza definitions database that is used \
@@ -840,7 +840,7 @@ defn defs-db-command () :
 
   ;Command definition
   Command("definitions-database",
-          AtLeastOneArg, "the .proj files to use to generate definitions for.",
+          AtLeastOneArg, "the .proj or .stanza files to use to generate definitions for.",
           to-tuple $ cat(new-flags, common-stanza-flags(["platform", "flags", "optimize"])),
           defs-db-msg, false, verify-args, intercept-no-match-exceptions(defs-db-action))
  

--- a/tests/defs-db-data/package1.stanza
+++ b/tests/defs-db-data/package1.stanza
@@ -1,0 +1,8 @@
+defpackage package1 :  
+  import core
+  import collections
+
+public defn package1-function () : false
+public deftype package1-Type
+public defmulti package1-multi (arg:package1-Type) -> False
+public val package1-VAR = 1

--- a/tests/defs-db-data/package2.stanza
+++ b/tests/defs-db-data/package2.stanza
@@ -6,3 +6,4 @@ public defn package2-function () : false
 public deftype package2-Type 
 public defmulti package2-multi (arg:package2-Type) -> False
 public val package2-VAR = 1
+

--- a/tests/defs-db-data/package2.stanza
+++ b/tests/defs-db-data/package2.stanza
@@ -1,0 +1,8 @@
+defpackage package2 :  
+  import core
+  import collections
+
+public defn package2-function () : false
+public deftype package2-Type 
+public defmulti package2-multi (arg:package2-Type) -> False
+public val package2-VAR = 1

--- a/tests/defs-db-data/stanza.proj
+++ b/tests/defs-db-data/stanza.proj
@@ -1,0 +1,2 @@
+package package1 defined-in "package1.stanza"
+package package2 defined-in "package2.stanza"

--- a/tests/stanza-tests.stanza
+++ b/tests/stanza-tests.stanza
@@ -6,3 +6,4 @@ defpackage stz/stanza-tests :
   import stz/test-trampoline
   import stz/test-paths
   import stz/test-dispatch-dag
+  import stz/test-defs-db

--- a/tests/stanza.proj
+++ b/tests/stanza.proj
@@ -6,6 +6,7 @@ package stz/test-utils defined-in "test-utils.stanza"
 package stz/test-trampoline defined-in "test-trampoline.stanza"
 package stz/test-paths defined-in "test-paths.stanza"
 package stz/test-dispatch-dag defined-in "test-dispatch-dag.stanza"
+package stz/test-defs-db defined-in "test-defs-db.stanza"
 
 ;Post-compilation tests
 ;First the compiler under development needs to be compiled

--- a/tests/test-defs-db.stanza
+++ b/tests/test-defs-db.stanza
@@ -11,29 +11,50 @@ defn extract (db:DefinitionsDatabase, package-name:Symbol) -> Tuple<Definition> 
       for def in value(kv) filter : 
         pkg-name(def) == package-name
 
-deftest(defsdb) single-proj-file : 
+defn test-harness (defs-db:DefinitionsDatabase, package:String) : 
+  val defs = extract(defs-db, to-symbol(package))
+  #EXPECT(length(defs) != 0)
+  val expected-items = [
+    "function" => SrcDefFunction
+    "multi"    => SrcDefMulti
+    "Type"     => SrcDefType
+    ; TODO : 
+    ; SrcDefVariable
+    ; SrcDefMethod
+    ; SrcDefPackage
+    ; SrcDefUnknown
+  ]
+  for expected in expected-items do : 
+    val sym = to-symbol $ "%_-%_" % [package, key(expected)]
+    val found? = find({name(_) == sym}, defs)
+    #EXPECT(found? is-not False)
+    match(found?:Definition):
+      #EXPECT(kind(found?) == value(expected))
+
+defn compile-db (input-files:Tuple<String>) : 
   val filename = "test-defs.db"
   val input = DefsDbInput(["tests/defs-db-data/stanza.proj"], false, [], false)
   defs-db(input, "test-defs.db")
   val istream = FileInputStream(filename)
   val defs-db = deserialize-definitions-database(istream)
   close(istream)
+  defs-db
+
+deftest(defsdb) single-proj-file : 
+  val db = compile-db(["tests/defs-db-data/stanza.proj"])
   for package in ["package1", "package2"] do : 
-    val defs = extract(defs-db, to-symbol(package))
-    #EXPECT(length(defs) != 0)
-    val expected-items = [
-      "function" => SrcDefFunction
-      "multi"    => SrcDefMulti
-      "Type"     => SrcDefType
-      ; TODO : 
-      ; SrcDefVariable
-      ; SrcDefMethod
-      ; SrcDefPackage
-      ; SrcDefUnknown
-    ]
-    for expected in expected-items do : 
-      val sym = to-symbol $ "%_-%_" % [package, key(expected)]
-      val found? = find({name(_) == sym}, defs)
-      #EXPECT(found? is-not False)
-      match(found?:Definition):
-        #EXPECT(kind(found?) == value(expected))
+    test-harness(db, package)
+
+deftest(defsdb) single-source-file : 
+  val db = compile-db(["tests/defs-db-data/package1.stanza"])
+  test-harness(db, "package1")
+
+deftest(defsdb) multi-source-files : 
+  val db = compile-db(["tests/defs-db-data/package1.stanza", "tests/defs-db-data/package2.stanza"])
+  for package in ["package1", "package2"] do : 
+    test-harness(db, package)
+
+deftest(defsdb) mixed-proj-and-source-files : 
+  val db = compile-db(["tests/defs-db-data/stanza.proj", "tests/defs-db-data/package2.stanza"])
+  for package in ["package1", "package2"] do : 
+    test-harness(db, package)

--- a/tests/test-defs-db.stanza
+++ b/tests/test-defs-db.stanza
@@ -1,0 +1,39 @@
+#use-added-syntax(tests)
+defpackage stz/test-defs-db : 
+  import core
+  import collections
+  import stz/defs-db
+  import stz/defs-db-serializer
+
+defn extract (db:DefinitionsDatabase, package-name:Symbol) -> Tuple<Definition> : 
+  to-tuple $ 
+    for kv in definitions(db) seq-cat : 
+      for def in value(kv) filter : 
+        pkg-name(def) == package-name
+
+deftest(defsdb) single-proj-file : 
+  val filename = "test-defs.db"
+  val input = DefsDbInput(["tests/defs-db-data/stanza.proj"], false, [], false)
+  defs-db(input, "test-defs.db")
+  val istream = FileInputStream(filename)
+  val defs-db = deserialize-definitions-database(istream)
+  close(istream)
+  for package in ["package1", "package2"] do : 
+    val defs = extract(defs-db, to-symbol(package))
+    #EXPECT(length(defs) != 0)
+    val expected-items = [
+      "function" => SrcDefFunction
+      "multi"    => SrcDefMulti
+      "Type"     => SrcDefType
+      ; TODO : 
+      ; SrcDefVariable
+      ; SrcDefMethod
+      ; SrcDefPackage
+      ; SrcDefUnknown
+    ]
+    for expected in expected-items do : 
+      val sym = to-symbol $ "%_-%_" % [package, key(expected)]
+      val found? = find({name(_) == sym}, defs)
+      #EXPECT(found? is-not False)
+      match(found?:Definition):
+        #EXPECT(kind(found?) == value(expected))


### PR DESCRIPTION
This PR changes the `definitions-database` command to allow for `.stanza` files to be used as inputs to the command. The desired use case is to index source files with or without a `.proj` file being present. 

Tests are also introduced to handle the commonly expected cases for this usage. 