### PR TITLE
Handle directory creation/deletion on Windows appropriately

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -10,6 +10,7 @@ defpackage clib
 
 protected extern memcpy: (ptr<?>, ptr<?>, long) -> ptr<?>
 protected extern memset: (ptr<?>, long, long) -> ptr<?>
+protected extern rmdir: (ptr<byte>) -> int
 protected extern remove: (ptr<byte>) -> int
 protected extern rename: (ptr<byte>, ptr<byte>) -> int
 protected extern symlink: (ptr<byte>, ptr<byte>) -> int
@@ -83,6 +84,7 @@ protected extern stz_memory_resize: (ptr<?>, long, long) -> int
   protected extern delete_process_pipes: (ptr<?>, ptr<?>, ptr<?>, int) -> int
   protected extern initialize_launcher_process: () -> int
 protected extern retrieve_process_state: (long, ptr<?>, int) -> int
+
 
 ;Math libraries
 protected extern exp: double -> double
@@ -4957,11 +4959,25 @@ public defn StringBuffer () :
 ;============================================================
 ;==================== Remove File ===========================
 ;============================================================
-
-public lostanza defn delete-file (path:ref<String>) -> ref<False> :
-   val r = call-c clib/remove(addr!(path.chars))
-   if r == -1 : throw(FileDeletionError(path, linux-error-msg()))
-   return false
+#if-defined(PLATFORM-WINDOWS) : 
+  lostanza defn delete-folder (path:ref<String>) -> ref<False> : 
+    val r = call-c clib/rmdir(addr!(path.chars))
+    if r == -1 : throw(FileDeletionError(path, linux-error-msg()))
+    return false
+  lostanza defn delete-plain-file (path:ref<String>) -> ref<False> : 
+    val r = call-c clib/remove(addr!(path.chars))
+    if r == -1 : throw(FileDeletionError(path, linux-error-msg()))
+    return false
+  public defn delete-file (path:String) : 
+    if file-exists?(path) and file-type(path) is DirectoryType : 
+      delete-folder(path)
+    else : 
+      delete-plain-file(path)
+#else : 
+  public lostanza defn delete-file (path:ref<String>) -> ref<False> : 
+    val r = call-c clib/remove(addr!(path.chars))
+    if r == -1 : throw(FileDeletionError(path, linux-error-msg()))
+    return false
 
 public deftype FileDeletionError <: Exception
 public defn FileDeletionError (path:String, msg:String) :
@@ -5330,13 +5346,20 @@ public defn delete-recursive (path:String) :
 ;================ Create a New Directory ====================
 ;============================================================
 
-extern mkdir: (ptr<byte>, long) -> int
-
-public lostanza defn create-dir (dirname:ref<String>, 
-                                 permissions:ref<Int>) -> ref<False> :
-  val result = call-c mkdir(addr!(dirname.chars), permissions.value)
-  if result == -1 : throw(CreateDirException(dirname, linux-error-msg()))  
-  return false
+#if-defined(PLATFORM-WINDOWS) :
+  extern _mkdir: (ptr<byte>) -> int
+  public lostanza defn create-dir (dirname:ref<String>, 
+                                  permissions:ref<Int>) -> ref<False> :
+    val result = call-c _mkdir(addr!(dirname.chars))
+    if result == -1 : throw(CreateDirException(dirname, linux-error-msg()))  
+    return false
+#else : 
+  extern mkdir: (ptr<byte>) -> int
+  public lostanza defn create-dir (dirname:ref<String>, 
+                                  permissions:ref<Int>) -> ref<False> :
+    val result = call-c mkdir(addr!(dirname.chars), permissions.value)
+    if result == -1 : throw(CreateDirException(dirname, linux-error-msg()))  
+    return false
 
 public defn create-dir (dirname:String) :
   create-dir(dirname, 0o777)


### PR DESCRIPTION
This PR introduces some changes to fix directory creation/deletion on windows. 

1. The C binding for `mkdir` is a function called `int _mkdir (const char*)` under mingw, which has one fewer argument. (mkdir exists, with the same function signature, but is marked deprecated)
2. `int remove (const char*)` fails with `Permission denied` when called on Windows with the argument pointing to a directory. 
3. A binding to `rmdir` is introduced, and `delete-file` is modified on Windows to check for the file type (if it exists) and call `rmdir` if the file type is `DirectoryType`. 

