### PR TITLE
Pass CLI args to scripts in the REPL/VM

### DIFF
--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -513,8 +513,10 @@ defn repl-command () :
     Flag("flags", ZeroOrMoreFlag, OptionalFlag,
       "The set of compile-time flags to be set before beginning this REPL session.")
     Flag("confirm-before-exit", ZeroFlag, OptionalFlag,
-      "If provided, the user will be asked to hit ENTER before the REPL process fully terminates.")]
-  
+      "If provided, the user will be asked to hit ENTER before the REPL process fully terminates.")
+    Flag("-", AllRemainingFlag, OptionalFlag,
+      "Arguments after this flag will be passed as the `command-line-arguments()` to the repl session")]
+
   ;Main action for command
   val repl-msg = "Launch the interactive Stanza REPL."
   defn launch-repl (cmd-args:CommandArgs) :
@@ -534,6 +536,10 @@ defn repl-command () :
 
       ;Add platform flag
       add-flag(platform-flag(OUTPUT-PLATFORM))
+
+      ;Setup command line arguments 
+      val cli-args = get?(cmd-args, "-", []) as Tuple<String>
+      set-command-line-arguments(cli-args)
 
       ;Launch REPL  
       repl(args(cmd-args))
@@ -567,7 +573,9 @@ defn run-command () :
     Flag("pkg", ZeroOrMoreFlag, OptionalFlag,
       "The set of additional directories to look in for .pkg files.")
     Flag("flags", ZeroOrMoreFlag, OptionalFlag,
-      "The set of compile-time flags to be set before beginning execution.")]
+      "The set of compile-time flags to be set before beginning execution.")
+    Flag("-", AllRemainingFlag, OptionalFlag,
+      "Arguments after this flag will be passed as the `command-line-arguments()` to the repl session")]
 
   ;Main action for command
   val launch-msg = "Execute Stanza files directly using the Stanza virtual machine."
@@ -585,6 +593,10 @@ defn run-command () :
 
     ;Add platform flag
     add-flag(platform-flag(OUTPUT-PLATFORM))
+
+    ;Setup command line arguments 
+    val cli-args = get?(cmd-args, "-", []) as Tuple<String>
+    set-command-line-arguments(cli-args)
 
     ;Run in REPL
     run-in-repl(args(cmd-args))

--- a/core/arg-parser.stanza
+++ b/core/arg-parser.stanza
@@ -43,6 +43,7 @@ public defenum FlagType :
   ZeroOrOneFlag
   AtLeastOneFlag
   ZeroOrMoreFlag  
+  AllRemainingFlag
 
 public defn default-verify (args:CommandArgs) :
   false
@@ -187,7 +188,7 @@ defn parse-args-and-flags (flags:Tuple<Flag>, arguments:Tuple<String>) ->
 
   ;Eat the arguments for the given flag type.
   defn* eat-flag-arg (flagname:String, type:FlagType) :
-    val args = eat-args-until-next-flag(type == GreedyFlag)
+    val args = eat-args-until-next-flag(type is GreedyFlag|AllRemainingFlag)
     ensure-valid-flag-arity(flagname, type, args)
     switch(type) :
       GreedyFlag: args[0]
@@ -196,6 +197,7 @@ defn parse-args-and-flags (flags:Tuple<Flag>, arguments:Tuple<String>) ->
       ZeroOrOneFlag: None() when empty?(args) else One(args[0])
       AtLeastOneFlag: args
       ZeroOrMoreFlag: args
+      AllRemainingFlag: args
 
   ;Eat the arguments until the next flag.
   defn* eat-args-until-next-flag (first-arg-greedy?:True|False) -> Tuple<String> :
@@ -221,6 +223,7 @@ defn ensure-valid-flag-arity (flagname:String, type:FlagType, args:Tuple<String>
     ZeroOrOneFlag: [0, 1]
     AtLeastOneFlag: [1, false]
     ZeroOrMoreFlag: [0, false]
+    AllRemainingFlag: [0, false]
   val actual-arity = length(args)
   val valid? = 
     match(max-arity:Int) : actual-arity >= min-arity and actual-arity <= max-arity
@@ -413,6 +416,7 @@ defn flag-description (f:Flag) :
       ZeroOrOneFlag: "Optional argument"
       AtLeastOneFlag: "At least one argument"
       ZeroOrMoreFlag: "Multiple arguments"
+      AllRemainingFlag: "Multiple arguments"
   defn desc-str () :
     if description(f) is False : ""
     else : Indented("\n\n%_" % [description(f)])


### PR DESCRIPTION
This PR adds two features to Stanza : 

- A new `Flag` type called `AllRemainingFlags` in `arg-parser` that represents a flag which consumes all subsequent arguments 
- A flag added to the `run` and `repl` commands, `--` which allows the caller to pass command line arguments to programs started with `stanza repl` or `stanza run`.  