### PR TITLE
runtime: properly close handle opened by `CreateFile`

### DIFF
--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -201,6 +201,9 @@ stz_long file_write_block (FILE* f, char* data, stz_long len) {
     LPSTR ret = stz_malloc(sizeof(CHAR) * MAX_PATH);
     int numchars = GetFinalPathNameByHandle(hFile, ret, MAX_PATH, FILE_NAME_OPENED);
 
+    // Close handle now that we no longer need it (important to do so!)
+    CloseHandle(hFile);
+
     // Return null if GetFinalPath fails.
     if(numchars == 0){
       stz_free(ret);


### PR DESCRIPTION
This fixes a handle leak in `windows_final_path_name()`, the existence of which causes further errors when trying to perform operations on the file (e.g. removing it).