### PR TITLE
Experiment with .file and .line directives

### DIFF
--- a/compiler/stz-asm-emitter.stanza
+++ b/compiler/stz-asm-emitter.stanza
@@ -17,7 +17,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
    ;     Error
    ;     -----
    defn RE () : fatal("Instruction %_ does not satisfy restrictions." % [ins])
-      
+
    ;     Types of Types
    ;     --------------
    defn #L (t:ASMType) : t is LongT
@@ -79,7 +79,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
    defn #nExM0! (x:Imm) :
      if use-procedure-linkage-table?(backend) :
        match(x:ExMem) :
-         RE() when offset(x) != 0     
+         RE() when offset(x) != 0
 
    ;     Dispatch on type of instruction
    ;     -------------------------------
@@ -133,7 +133,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
                (op:ShlOp) : shf-op()
                (op:ShrOp) : shf-op()
                (op:AshrOp) : shf-op()
-               (op:EqOp) : cmp-op() 
+               (op:EqOp) : cmp-op()
                (op:NeOp) : cmp-op()
                (op:LtOp) : cmp-op()
                (op:GtOp) : cmp-op()
@@ -161,7 +161,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
                (op:ShlOp) : shf-op()
                (op:ShrOp) : shf-op()
                (op:AshrOp) : shf-op()
-               (op:EqOp) : cmp-op() 
+               (op:EqOp) : cmp-op()
                (op:NeOp) : cmp-op()
                (op:LtOp) : cmp-op()
                (op:GtOp) : cmp-op()
@@ -188,7 +188,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
                (op:ShlOp) : shf-op()
                (op:ShrOp) : shf-op()
                (op:AshrOp) : shf-op()
-               (op:EqOp) : cmp-op() 
+               (op:EqOp) : cmp-op()
                (op:NeOp) : cmp-op()
                (op:LtOp) : cmp-op()
                (op:GtOp) : cmp-op()
@@ -208,7 +208,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
                (op:SubOp) : ncom-op()
                (op:MulOp) : reg-op()
                (op:DivOp) : ncom-op()
-               (op:EqOp) : cmp-op() 
+               (op:EqOp) : cmp-op()
                (op:NeOp) : cmp-op()
                (op:LtOp) : cmp-op()
                (op:GtOp) : cmp-op()
@@ -225,7 +225,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
          if #IL(t) : (#R0!(x1), #R3!(x2), #R!(y), #R!(z), #DIVMOD!(op), #neq!(x1, z), #neq!(x2, z))
          else : RE()
       (ins:Load) :
-         val [t, x, y] = [type(ins), x(ins), y(ins)]         
+         val [t, x, y] = [type(ins), x(ins), y(ins)]
          #nExM!(y)
          if #L(t) : (#SR!(x), #SRIM!(y))
          else if #i(t) : (#R!(x), #SRIM!(y))
@@ -257,7 +257,7 @@ defn check-restriction (ins:Ins, backend:Backend) :
          false
       (ins:DefData|DefText|DefByte|DefInt|DefLong|DefDirectives|DefExportLabel|
            DefFloat|DefDouble|DefString|DefBytes|DefSpace|DefLabel|Comment) :
-         false      
+         false
 
 
 ;============================================================
@@ -357,7 +357,7 @@ defn gen (os:OutputStream, ins:Ins, backend:Backend) :
          (y) :
             if #i(t) : #println(os, "   mov%_ %_, %_" % [size-suffix(t), #imm(t,y), #imm(t,x)])
             else if #f(t) : #println(os, "   movs%_ %_, %_" % [size-suffix(t), #imm(t,y), #imm(t,x)])
-            else : fatal("Unreachable")      
+            else : fatal("Unreachable")
 
    defn #pic-set (x:Loc, y:ExMem) :
       #println(os, "  movq %_@GOTPCREL(%%rip), %_" % [#lbl(y), #imm(LongT(),x)])
@@ -375,14 +375,14 @@ defn gen (os:OutputStream, ins:Ins, backend:Backend) :
             if #L(a) : #L(b)
             else if #I(a) : #IL(b)
             else : true
-         ;Truncation Conversion   
+         ;Truncation Conversion
          if int-less-eq?(xtype, ytype) :
             #set(xtype, x, y)
-         ;Extension Conversion   
+         ;Extension Conversion
          else :
             val mov = "movz" when #B(ytype) else "movs"
             #println(os, "   %_%_%_ %_, %_" % [mov, ysz, xsz, #imm(ytype, y), #imm(xtype, x)])
-            
+
       ;Float to Float Conversions
       else if #f(xtype) and #f(ytype) :
          ;If Equal
@@ -390,16 +390,16 @@ defn gen (os:OutputStream, ins:Ins, backend:Backend) :
             #set(xtype, x, y)
          else :
             #println(os, "   cvts%_2s%_ %_, %_" % [ysz, xsz, #imm(ytype, y), #imm(xtype, x)])
-         
+
       ;Float to Integer Conversions
       else if #i(xtype) and #f(ytype) :
          #println(os, "   cvtts%_2si%_ %_, %_" % [ysz, xsz, #imm(ytype, y), #imm(xtype, x)])
-            
-      ;Integer to Float Conversions      
+
+      ;Integer to Float Conversions
       else if #f(xtype) and #i(ytype) :
          #println(os, "   cvtsi2s%_%_ %_, %_" % [xsz, ysz, #imm(ytype, y), #imm(xtype, x)])
-            
-      ;Error      
+
+      ;Error
       else :
          fatal("Unreachable")
 
@@ -721,6 +721,8 @@ defn gen (os:OutputStream, ins:Ins, backend:Backend) :
       (ins:DefDirectives) : println(os, "   .section .drectve")
       (ins:DefExportLabel) : #println(os, \<S>   .asciz "  -export:\"%_\""<S> % [value(ins)])
       (ins:Comment) : #println(os, "//%_" % [msg(ins)])
+      (ins:DefFile) : #println(os, "   .file \"%_\"" % [filename(ins)])
+      (ins:DefLine) : #println(os, "   .line %_" % [line(ins)])
 
 ;============================================================
 ;===================== Driver ===============================
@@ -732,5 +734,3 @@ public defn emit-asm (o:OutputStream, e:Ins, backend:Backend) -> False :
   #if-not-defined(OPTIMIZE) :
     check-restriction(e, backend)
   gen(o,e,backend)
-
-

--- a/compiler/stz-asm-ir.stanza
+++ b/compiler/stz-asm-ir.stanza
@@ -16,9 +16,9 @@ defpackage stz/asm-ir :
 # Local Labels and References #
 
 Label: creates a package-local label. This label is only visible
-within the package assembly code. 
-  
-LocalMem: refers to a label defined in the current package. 
+within the package assembly code.
+
+LocalMem: refers to a label defined in the current package.
 
 # Linked Labels and References #
 
@@ -33,7 +33,7 @@ Mem: refers to an absolute label. Note that the only absolute labels
 that are known to a package are the system labels, such as
 current_stack, registers, heap_pointer, etc.
 
-There is no way for a package to define an absolute label. 
+There is no way for a package to define an absolute label.
 
 ;============================================================
 ;=======================================================<doc>
@@ -106,7 +106,7 @@ defmethod equal? (a:ASMType, b:ASMType) :
 
 public defast :
   ;Instructions
-  deftype Ins  
+  deftype Ins
   defnodes Ins :
     ;==== Local Instructions ====
     XchgIns :
@@ -205,6 +205,10 @@ public defast :
     ;==== Misc Instructions ====
     Comment :
       msg: String
+    DefFile :
+      filename : String
+    DefLine :
+      line : Int
 
   ;Mapper Utilities
   defmapper (f:Imm -> Imm) :
@@ -325,7 +329,7 @@ defmethod print (o:OutputStream, i:Ins) :
     (i:Label) : "L<%~> : %_" % [n(i), trace-entry(i)]
     (i:LinkLabel) : "linked %_" % [id(i)]
     (i:ExLabel) : "L<%~>" % [name(i)]
-    (i:Match) : "   match(%,) %_ no: %_" % [xs(i), branches(i), no-branch(i)]    
+    (i:Match) : "   match(%,) %_ no: %_" % [xs(i), branches(i), no-branch(i)]
     (i:Dispatch) : "   dispatch(%,) %_ no: %_ amb: %_" % [xs(i), branches(i), no-branch(i), amb-branch(i)]
     (i:MethodDispatch) : "  method-dispatch(%_) no: %_ amb: %_" % [multi(i), no-branch(i), amb-branch(i)]
     (i:DefData) : "   .data"

--- a/compiler/stz-compiler-main.stanza
+++ b/compiler/stz-compiler-main.stanza
@@ -24,11 +24,11 @@ Input:
   denv: DEnv
   packages: Seqable<EPackage|VMPackage|Pkg>
   input-order: Tuple<Symbol>
-  
+
 Output:
   packages: Tuple<EPackage|VMPackage|Pkg>
 
-Reorders the given input by their proper dependency order. 
+Reorders the given input by their proper dependency order.
 
 # Combine multiple EL packages into a single optimized VMPackage #
 
@@ -146,7 +146,7 @@ public defn compile (proj-manager:ProjManager,
                      pkg-dir:False|String,
                      backend:Backend,
                      optimize?:True|False,
-                     verbose?:True|False) -> CompilationResult :  
+                     verbose?:True|False) -> CompilationResult :
   defn driver () :
     val denv = DEnv()
     val result = compile-to-el $ new FrontEndInputs :
@@ -163,7 +163,7 @@ public defn compile (proj-manager:ProjManager,
 
     ;Record filestamp of any output pkgs
     val output-pkgs = Vector<FileStamp>()
-    
+
     ;Save optimized packages if necessary
     if pkg-dir is String and optimize? :
       within save = save-pkgs(pkgstamp-table, output-pkgs) :
@@ -204,14 +204,14 @@ public defn compile (proj-manager:ProjManager,
                       pkgstamps(result),
                       to-tuple(output-pkgs))
 
-  defn save-pkgs (body:(Pkg -> False) -> ?,  
+  defn save-pkgs (body:(Pkg -> False) -> ?,
                   pkgstamp-table:HashTable<Symbol,PackageStamp>,
                   output-pkgs:Vector<FileStamp>) :
     match(pkg-dir:String) :
       val saved-pkgs = Vector<SavedPkg>()
       defn save-pkg (pkg:Pkg) :
         val filename = save-package(pkg-dir as String, pkg)
-        val stamp = pkgstamp-table[name(pkg)]      
+        val stamp = pkgstamp-table[name(pkg)]
         val filestamp = filestamp(filename)
         add(output-pkgs, filestamp)
         val full-source-path = resolve-path!(source-file(location(stamp)) as String)
@@ -258,8 +258,8 @@ public defn compile (proj-manager:ProjManager,
           (std-pkg:StdPkg) :
             compile-stdpkg(filestream, std-pkg, stitcher)
       emit-all-system-stubs(filestream, stitcher, stubs)
-      
-    ;Create filestream and compile to it.  
+
+    ;Create filestream and compile to it.
     val filestream = FileOutputStream(filename)
     try: compile(filestream)
     finally: close(filestream)
@@ -272,7 +272,7 @@ public defn compile (proj-manager:ProjManager,
     if return-instructions? :
       val buffer = Vector<Ins>()
       val emitter = buffer-emitter(buffer, emitter(stitcher, name(npkg), file-emitter(filestream, stubs)))
-      emit-normalized-package(npkg, emitter, stubs)      
+      emit-normalized-package(npkg, emitter, stubs)
       to-tuple(buffer)
     else :
       val emitter = emitter(stitcher, name(npkg), file-emitter(filestream, stubs))
@@ -286,30 +286,37 @@ public defn compile (proj-manager:ProjManager,
       val buffer = Vector<Ins>()
       emit-normalized-package(npkg, buffer-emitter(buffer, stubs), stubs)
       save-pkg(StdPkg(vmpackage, to-tuple(buffer), datas(npkg)))
-    
+
   defn emit-normalized-package (npkg:NormVMPackage, emitter:CodeEmitter, stubs:AsmStubs) :
     ;Create the debug table so that we can add debug comments
     ;to each function.
     val debug-table = to-inttable<VMDebugInfo> $
       for e in entries(debug-table(vmpackage(npkg))) seq :
         id(e) => e
-    defn function-comment (id:Int) -> Comment :
-      Comment $ match(get?(debug-table, id)) :
+    ;Emit each function
+    var previous-filename:String = ""
+    for f in funcs(vmpackage(npkg)) do :
+      val id = id(f)
+      match(get?(debug-table, id)) :
         (dbg:VMDebugInfo) :
           val name = match(name(dbg)) :
             (name:String) : name
             (f:False) : "Unnamed function"
-          val info-str = match(info(dbg)) :
-            (info:FileInfo) : " at %_" % [info]
-            (f:False) : ""
-          string-join([name info-str])
+          match(info(dbg)) :
+            (info:FileInfo) :
+              emit(emitter, Comment $ string-join([name " at %_" % [info]]))
+              emit(emitter, LinkLabel(id))
+              val filename = filename(info)
+              if previous-filename != filename :
+                previous-filename = filename
+                emit(emitter, DefFile $ filename)
+              emit(emitter, DefLine $ line(info))
+            (f:False) :
+              emit(emitter, Comment $ name)
+              emit(emitter, LinkLabel(id))
         (f:False) :
-          "Unnamed function"
-
-    ;Emit each function
-    for f in funcs(vmpackage(npkg)) do :
-      emit(emitter, function-comment(id(f)))
-      emit(emitter, LinkLabel(id(f)))
+          emit(emitter, Comment $ "Unnamed function")
+          emit(emitter, LinkLabel(id))
       allocate-registers(func(f), emitter, backend, stubs, false)
 
   defn emit-all-system-stubs (filestream:OutputStream, stitcher:Stitcher, stubs:AsmStubs) :
@@ -340,10 +347,10 @@ public defn compile (proj-manager:ProjManager,
         add(buffer, i)
       defmethod unique-label (this) :
         unique-id(stubs)
-        
+
   ;Launch
   driver()
-  
+
 ;============================================================
 ;============= Collapsing a Normalized Package ==============
 ;============================================================

--- a/compiler/stz-pkg.stanza
+++ b/compiler/stz-pkg.stanza
@@ -16,7 +16,7 @@ defpackage stz/pkg :
            TypeofOp, XchgIns, SetIns, ConvertIns, InterpretIns, UnaOp, BinOp,
            DualOp, Load, Store, Call, Return, Goto, Break, Label, LinkLabel,
            ExLabel, Match, Dispatch, MethodDispatch, DefData, DefText, DefDirectives, DefExportLabel, DefByte,
-           DefInt, DefLong, DefFloat, DefDouble, DefString, DefBytes, DefSpace, DefLabel, Comment) => asm-
+           DefInt, DefLong, DefFloat, DefDouble, DefString, DefBytes, DefSpace, DefLabel, Comment, DefFile, DefLine) => asm-
   import stz/visibility
   import stz/dl-ir
   import stz/basic-ops
@@ -98,13 +98,13 @@ public defn PkgLoader (optimized?:True|False) :
   defn add-pkg (pkg:Pkg, filename:String) :
     pkg-table[name(pkg)] = pkg
     filename-table[name(pkg)] = filename
-  
+
   new PkgLoader :
     defmethod load-pkg (this, filename:String) :
       val pkg = load-package(filename, false, optimized?)
       add-pkg(pkg, filename)
       pkg
-      
+
     defmethod load-pkg (this, name:Symbol) :
       within update?(pkg-table, name) :
         match(find-pkg(name, optimized?)) :
@@ -114,15 +114,15 @@ public defn PkgLoader (optimized?:True|False) :
             pkg
           (_:False) :
             throw(NoPackageException(name))
-            
+
     defmethod source-file (this, name:Symbol) :
       filename-table[name]
 
     defmethod load-dependencies (this, already-loaded:Seqable<Symbol>) :
-      val loadset = to-hashset<Symbol>(already-loaded)    
+      val loadset = to-hashset<Symbol>(already-loaded)
       defn ensure-loaded (name:Symbol) :
         if not loadset[name] and not key?(pkg-table, name) :
-          ensure-dependencies-loaded(load-pkg(this, name))          
+          ensure-dependencies-loaded(load-pkg(this, name))
       defn ensure-dependencies-loaded (pkg:Pkg) :
         do(ensure-loaded, imported-packages(packageio(pkg)))
       do(ensure-dependencies-loaded, to-tuple(values(pkg-table)))
@@ -156,7 +156,7 @@ public defn load-package (filename:String, expected-name:Symbol|False, optimized
   ensure-expected-optimization!(pkg, filename, optimized?)
   ;Return the pkg
   pkg
-  
+
 defn ensure-expected-name! (pkg:Pkg, filename:String, name:Symbol) :
   if /name(pkg) != name :
     throw(WrongPackageNameException(filename, name, /name(pkg)))
@@ -442,7 +442,7 @@ defserializer (out:FileOutputStream, in:FileInputStream) :
     EDefType: (n:int, parent:opt<EType>(etype), children:tuple(int))
     EDefObject: (n:int, parent:etype, ntargs:int, nargs:int, methods:tuple(int))
     EDefTypeObject: (n:int, nargs:int, type:etype)
-    
+
   defunion etype (EType) :
     EByte: ()
     EInt: ()
@@ -903,6 +903,8 @@ defserializer (out:FileOutputStream, in:FileInputStream) :
     asm-DefSpace: (size:int)
     asm-DefLabel: (n:int)
     asm-Comment: (msg:string)
+    asm-DefFile: (filename:string)
+    asm-DefLine: (line:int)
 
   defunion branch (Branch) :
     Branch: (tags:list(typeset), dst:imm)

--- a/scripts/lgfinish.sh
+++ b/scripts/lgfinish.sh
@@ -1,0 +1,3 @@
+gcc -std=gnu99 -c core/sha256.c -O3 -o build/sha256.o -fPIC -I include
+gcc -std=gnu99 -c compiler/cvm.c -O3 -o build/cvm.o -fPIC -I include
+gcc -std=gnu99 runtime/driver.c runtime/linenoise.c build/cvm.o build/sha256.o lstanza.s -o lstanza -DPLATFORM_LINUX -lm -ldl -fPIC -I include -g1


### PR DESCRIPTION
Stanza functions are annotated with FileInfo(filename, line, position). Generate GNU assembler .file/.line directives to specify source locations of the code generated for the functions.

This will only allow to set a break point at function entry file:line. Other file:line locations can be incorrect. The assembler automatically increments the line with each assembly line. Once FileInfo is propagated to each generated assembly instruction, this problem will go away.

Build instructions:
1. Generate `lstanza.s` with
`stanza core/stanza.proj compiler/stanza.proj stz/driver -o newstanza`
`./newstanza build-stanza.proj stz/driver -s lstanza.s`
2. Build lstanza executable with  `scripts/lgfinish.sh`. You may need to change `PLATFORM_LINUX` there.