### PR TITLE
Refactored indexing algorithm and DefinitionsDatabase

### DIFF
--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -3,6 +3,7 @@ defpackage stz/defs-db-serializer :
   import core
   import collections
   import stz/serializer
+  import stz/visibility
 
 ;===============================================================================
 ; =============================== Types ========================================
@@ -23,30 +24,60 @@ public public defenum SrcDefinitionSource :
   SrcDefinition
 
 doc: "A single defined item"
-public defstruct Definition : 
-  name:      Symbol,
-  file-info: FileInfo 
-  kind:      SrcDefinitionKind 
-  source:    SrcDefinitionSource
-  pkg-name:  Symbol,
+public defstruct Definition <: Equalable : 
+  name:Symbol
+  file-info:FileInfo 
+  kind:SrcDefinitionKind 
+  source:SrcDefinitionSource
+  pkg-name:Symbol
+  visibility:Visibility
 
 doc: "A collection of definitions and reserved words in a stanza project"
 public defstruct DefinitionsDatabase: 
-  reserved-words: Tuple<String>, 
-  definitions: HashTable<Symbol, List<Definition>>
+  reserved-words:Tuple<String>
+  definitions:HashTable<Symbol, List<Definition>>
+  packages:Tuple<PackageDefinition>
+
+public defstruct PackageDefinition : 
+  name:Symbol
+  file-name:String
+  imports:Tuple<PackageImport>
+
+public defstruct PackageImport : 
+  name:Symbol
+  prefixes:Tuple<PackageImportPrefix>
+
+public defstruct PackageImportPrefix : 
+  sources:Tuple<Symbol>
+  prefix:Symbol
 
 ;===============================================================================
 ; =========================== Serializers =====================================
 ;===============================================================================
 public defserializer (out:OutputStream, in:InputStream) : 
   defunion definitions-database (DefinitionsDatabase) :
-    DefinitionsDatabase : (reserved-words:tuple(string), definitions:table)
+    DefinitionsDatabase : (reserved-words:tuple(string), definitions:table, packages:tuple(package-definition))
 
   defunion definition (Definition) : 
-    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src, pkg-name:symbol)
+    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src, pkg-name:symbol, visibility:visibility)
+  
+  defunion package-definition (PackageDefinition) : 
+    PackageDefinition : (name:symbol, file-name:string, imports:tuple(package-import))
+
+  defunion package-import (PackageImport) : 
+    PackageImport : (name:symbol, prefixes:tuple(package-import-prefix))
+
+  defunion package-import-prefix (PackageImportPrefix) : 
+    PackageImportPrefix : (sources:tuple(symbol), prefix:symbol)
   
   defunion fileinfo (FileInfo) :
     FileInfo : (filename:string, line:int, column:int)
+
+  reader defn read-visibility () : 
+    Visibility(read-int())
+
+  writer defn write-visibility (v:Visibility) : 
+    write-int(to-int(v))
 
   reader defn read-table () :
     val n = read-int()
@@ -168,11 +199,40 @@ defn from-var-int (N: () -> Byte) -> Int :
     250Y : B0() + 250
     else : to-int(x)
 
+defmethod equal? (l:Definition, r:Definition) :
+  println("comparing:\nl:%_\nr:%_" % [l, r])
+  let : 
+    val li = file-info(l)
+    val ri = file-info(r)
+    #for field in [filename line column] : 
+      println("%_ == %_ ? %_" % [
+        field(li), field(ri)
+        field(li) == field(ri)
+      ])
+    println("%_ == %_ ? %_" % [li, ri, li == ri])
+  #for field in [name file-info kind source pkg-name visibility] : 
+    println("%_ == %_ ? %_" % [
+      field(l), field(r)
+      field(l) == field(r)
+    ])
+  name(l)       == name(r)      and 
+  file-info(l)  == file-info(r) and  
+  kind(l)       == kind(r)      and  
+  source(l)     == source(r)    and 
+  pkg-name(l)   == pkg-name(r)  and 
+  visibility(l) == visibility(r)
+
 ;===============================================================================
 ; ============================= Printers =======================================
 ;===============================================================================
 defmethod print (o:OutputStream, def:Definition):
-  print(o, "Definition(name:%_,kind:%_,source:%_) in %_ @ %_" % [name(def), kind(def), source(def), pkg-name(def), file-info(def)])
+  print(o, "Definition %_ defined at %_:" % [name(def), file-info(def)])
+  val oo = IndentedStream(o)
+  lnprint(oo, "kind: %_" % [kind(def)])
+  lnprint(oo, "source: %_" % [source(def)])
+  lnprint(oo, "pkg-name: %_" % [pkg-name(def)])
+  lnprint(oo, "visibility: %_" % [visibility(def)])
+  ; print(o, "Definition(name:%_,kind:%_,source:%_) in %_ @ %_" % [name(def), kind(def), source(def), pkg-name(def), file-info(def)])
 
 defmethod print (o:OutputStream, ddb:DefinitionsDatabase):
   val o2 = IndentedStream(o)
@@ -181,19 +241,19 @@ defmethod print (o:OutputStream, ddb:DefinitionsDatabase):
   lnprint(o, "Definitions:")
   do(lnprint{o2, _}, definitions(ddb))
 
-defmethod print (o:OutputStream, kind:SrcDefinitionKind):
-  print{o, _} $ 
-    match(kind):
-      (_:SrcDefUnknown):  "unknown", 
-      (_:SrcDefMulti):    "multi", 
-      (_:SrcDefMethod):   "method", 
-      (_:SrcDefFunction): "function", 
-      (_:SrcDefVariable): "variable", 
-      (_:SrcDefType):     "type", 
-      (_:SrcDefPackage):  "package",
+; defmethod print (o:OutputStream, kind:SrcDefinitionKind):
+;   print{o, _} $ 
+;     match(kind):
+;       (_:SrcDefUnknown):  "unknown", 
+;       (_:SrcDefMulti):    "multi", 
+;       (_:SrcDefMethod):   "method", 
+;       (_:SrcDefFunction): "function", 
+;       (_:SrcDefVariable): "variable", 
+;       (_:SrcDefType):     "type", 
+;       (_:SrcDefPackage):  "package",
 
-defmethod print (o:OutputStream, src:SrcDefinitionSource):
-  print{o, _} $
-    match(src):
-      (_:SrcDefinition): ".stanza"
-      (_:PkgDefinition): ".pkg|.fpkg"
+; defmethod print (o:OutputStream, src:SrcDefinitionSource):
+;   print{o, _} $
+;     match(src):
+;       (_:SrcDefinition): ".stanza"
+;       (_:PkgDefinition): ".pkg|.fpkg"

--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -200,21 +200,6 @@ defn from-var-int (N: () -> Byte) -> Int :
     else : to-int(x)
 
 defmethod equal? (l:Definition, r:Definition) :
-  println("comparing:\nl:%_\nr:%_" % [l, r])
-  let : 
-    val li = file-info(l)
-    val ri = file-info(r)
-    #for field in [filename line column] : 
-      println("%_ == %_ ? %_" % [
-        field(li), field(ri)
-        field(li) == field(ri)
-      ])
-    println("%_ == %_ ? %_" % [li, ri, li == ri])
-  #for field in [name file-info kind source pkg-name visibility] : 
-    println("%_ == %_ ? %_" % [
-      field(l), field(r)
-      field(l) == field(r)
-    ])
   name(l)       == name(r)      and 
   file-info(l)  == file-info(r) and  
   kind(l)       == kind(r)      and  
@@ -223,7 +208,7 @@ defmethod equal? (l:Definition, r:Definition) :
   visibility(l) == visibility(r)
 
 ;===============================================================================
-; ============================= Printers =======================================
+;============================== Printers =======================================
 ;===============================================================================
 defmethod print (o:OutputStream, def:Definition):
   print(o, "Definition %_ defined at %_:" % [name(def), file-info(def)])
@@ -232,7 +217,6 @@ defmethod print (o:OutputStream, def:Definition):
   lnprint(oo, "source: %_" % [source(def)])
   lnprint(oo, "pkg-name: %_" % [pkg-name(def)])
   lnprint(oo, "visibility: %_" % [visibility(def)])
-  ; print(o, "Definition(name:%_,kind:%_,source:%_) in %_ @ %_" % [name(def), kind(def), source(def), pkg-name(def), file-info(def)])
 
 defmethod print (o:OutputStream, ddb:DefinitionsDatabase):
   val o2 = IndentedStream(o)
@@ -240,20 +224,3 @@ defmethod print (o:OutputStream, ddb:DefinitionsDatabase):
   do(lnprint{o2, _}, reserved-words(ddb))
   lnprint(o, "Definitions:")
   do(lnprint{o2, _}, definitions(ddb))
-
-; defmethod print (o:OutputStream, kind:SrcDefinitionKind):
-;   print{o, _} $ 
-;     match(kind):
-;       (_:SrcDefUnknown):  "unknown", 
-;       (_:SrcDefMulti):    "multi", 
-;       (_:SrcDefMethod):   "method", 
-;       (_:SrcDefFunction): "function", 
-;       (_:SrcDefVariable): "variable", 
-;       (_:SrcDefType):     "type", 
-;       (_:SrcDefPackage):  "package",
-
-; defmethod print (o:OutputStream, src:SrcDefinitionSource):
-;   print{o, _} $
-;     match(src):
-;       (_:SrcDefinition): ".stanza"
-;       (_:PkgDefinition): ".pkg|.fpkg"

--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -33,7 +33,7 @@ public defstruct Definition <: Equalable :
   visibility:Visibility
 
 doc: "A collection of definitions and reserved words in a stanza project"
-public defstruct DefinitionsDatabase: 
+public defstruct DefinitionsDatabase : 
   reserved-words:Tuple<String>
   definitions:HashTable<Symbol, List<Definition>>
   packages:Tuple<PackageDefinition>
@@ -48,8 +48,8 @@ public defstruct PackageImport :
   prefixes:Tuple<PackageImportPrefix>
 
 public defstruct PackageImportPrefix : 
-  sources:Tuple<Symbol>
-  prefix:Symbol
+  names:False|Tuple<Symbol>
+  prefix:String
 
 ;===============================================================================
 ; =========================== Serializers =====================================
@@ -68,7 +68,7 @@ public defserializer (out:OutputStream, in:InputStream) :
     PackageImport : (name:symbol, prefixes:tuple(package-import-prefix))
 
   defunion package-import-prefix (PackageImportPrefix) : 
-    PackageImportPrefix : (sources:tuple(symbol), prefix:symbol)
+    PackageImportPrefix : (names:opt<Tuple<Symbol>>(tuple(symbol)), prefix:string)
   
   defunion fileinfo (FileInfo) :
     FileInfo : (filename:string, line:int, column:int)
@@ -105,6 +105,18 @@ public defserializer (out:OutputStream, in:InputStream) :
   writer defn write-tuple<?T> (f: T -> False, xs:Tuple<?T>) :
     write-int(length(xs))
     do(f, xs)
+
+  reader defn read-opt<T> (f: () -> T) :
+    val n = read-byte()
+    f() when n == 1Y
+
+  writer defn write-opt<T> (f: T -> False, x:T|False) :
+    match(x) :
+      (x:False) :
+        write-byte(0Y)
+      (x:T) :
+        write-byte(1Y)
+        f(x)
 
   defatom src-def-src (x:SrcDefinitionSource): 
     writer: 

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -49,7 +49,6 @@ protected defn compile-input (input:DefsDbInput) -> [NameMap, Seqable<IPackage|P
   val input-packages = all-packages(proj-file)
   val proj-files-and-packages = to-tuple $
     cat(proj-files(input), input-packages)
-  println("input-packages: [%,]" % [proj-files-and-packages])
 
   ; Compute the build settings (input to the compiler)
   val build-settings = BuildSettings(
@@ -249,14 +248,16 @@ public defn kindof (e:IExp) :
 
 ; Retrieve the name of an expression from the Name map, if it exists
 defn lookup (nm:NameMap, e:IExp) -> False|Symbol :
-  match(e:VarN) : 
-    name(nm[n(e)])
+  match(e:VarN) :
+    val n = n(e)
+    if key?(nm, n) :
+      name(nm[n])
 
 ; Lookup the name of an Indexable from the name map.
 defn name? (i:Indexable, nm:NameMap) -> False|Symbol :
   val exp-name = 
     match(i) : 
-      (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti|IDefChild) : 
+      (e:IDef|ILSDef|ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti|IDefChild) : 
         name(e)
       (e:IDefType) : 
         class(e)

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -19,27 +19,39 @@ defpackage stz/defs-db :
 ;============================================================
 ;=================== Driver Arguments =======================
 ;============================================================
-
 public defstruct DefsDbInput :
   proj-files: Tuple<String>
   platform: Symbol|False
   flags: Tuple<Symbol>
   optimize?: True|False
 
+; Main entry point, given the input data and an output filename, 
+; compile to IL-IR, create the definitions database, and serialize it 
+; to the output file.
 public defn defs-db (input:DefsDbInput, filename:String) :
+  ; Compile the input 
+  val [namemap, packages] = compile-input(input)
+
+  ;Call generation of definitions database
+  gen-defs-db(filename, namemap, packages)
+
+; Helper function to compile the input data into IL-IR.
+protected defn compile-input (input:DefsDbInput) -> [NameMap, Seqable<IPackage|Pkg>] :
   ;Compute platform
   read-config-file()
-  val db-platform = match(platform(input)) :
-    (s:Symbol) : s
-    (f:False) : OUTPUT-PLATFORM
-    
+  val db-platform = 
+    match(platform(input)) : 
+      (s:Symbol) : s
+      (f:False)  : OUTPUT-PLATFORM
+  
   ;Read all listed packages from given project files
   val proj-file = read-proj-files(proj-files(input), db-platform)
   val input-packages = all-packages(proj-file)
-
-  ;Construct build settings
   val proj-files-and-packages = to-tuple $
     cat(proj-files(input), input-packages)
+  println("input-packages: [%,]" % [proj-files-and-packages])
+
+  ; Compute the build settings (input to the compiler)
   val build-settings = BuildSettings(
     BuildPackages(proj-files-and-packages), ;inputs
     [],                                     ;vm-packages
@@ -53,111 +65,128 @@ public defn defs-db (input:DefsDbInput, filename:String) :
     [],                                     ;ccflags
     flags(input))                           ;flags
     
-  ;Compute dependencies
-  val dep-result = dependencies(build-settings, true)
+  ;Compute dependencies (compiles to IL-IR)
+  val deps = dependencies(build-settings, true)
 
-  ;Call generation of definitions database
-  gen-defs-db(filename, namemap(dep-result), packages(dep-result))
+  ; return namemap and list of packages
+  [namemap(deps), packages(deps)]
 
+;==============================================================================
+;========================= Main Indexing Algorithm ============================
+;==============================================================================
+; The `Indexed` struct is a helper that contains extracted metadata from IL-IR.
+; before being associated with a package. 
+;
+;- kind:       The kind of originating expression (see SrcDefinitionKind)
+;- visibility: The visibility of the expression (public|private|protected)
+;- name:       The extracted name of the indexed expression
+;- info:       The associated file info of the expression.
+protected defstruct Indexed <: Equalable : 
+  kind:SrcDefinitionKind
+  visibility:Visibility
+  name:Symbol
+  info:FileInfo
+with : 
+  printer => true
 
-;============================================================
-;============= Retrieve All Packages in Proj File ===========
-;============================================================
+; An Indexable is an IExp that can be meaningfully indexed in the DefinitionsDatabase 
+; structure. Currently supported are functions, multis, methods, types, and children
+; in both Hi and Lo stanza.
+deftype Indexable :  
+  IDef         <: Indexable
+  IDefn        <: Indexable
+  IDefmulti    <: Indexable
+  IDefmethod   <: Indexable
+  IDefType     <: Indexable
+  IDefChild    <: Indexable
+  ILSDef       <: Indexable
+  ILSDefn      <: Indexable
+  ILSDefmethod <: Indexable
+  ILSDefType   <: Indexable
 
-defn all-packages (proj-file:ProjFile) -> Tuple<Symbol> :
-  val defined = filter-by<DefinedInStmt>(stmts(proj-file))
-  to-tuple(seq(package, defined))
+; Depth first walk of the IL-IR to flatten into a sequence of `Indexed`, or 
+; IExp nodes that have a meaningful name and FileInfo
+;
+; Input: The top level IExp nodes from IL-IR, and a NameMap to lookup associated
+;        names of the nodes we will index.
+;
+; Output: A sequence of indexed expressions.
+;
+; Expected Behavior : 
+; - When encountering an `IVisibility` node, traverse its child using that node's visibility
+; - When encountering an `IBegin`, traverse its children with the current visibility.
+; - The initial visibility is `Private`
+; - If an expression is not `Indexable`, it is skipped
+; - If an `Indexable` does not have an `info`, it is skipped
+; - If an `Indexable`'s name cannot be found, it is skipped 
+;
+protected defn index-expressions (exps:Seqable<IExp>, nm:NameMap) -> Seq<Indexed> :
+  var print? = false
+  generate : 
+    defn loop (e:IExp, current-visibility:Visibility) :
+      match(e) : 
+        ; Case 1: We encounter a visibility node. Walk its
+        ;         child with the new visibility.
+        (v:IVisibility) : 
+          loop(exp(v), visibility(v))
+        ; Case 2: We encounter a `Begin` node. Walk its children
+        ;         reusing the current visibility
+        (b:IBegin) : 
+          do(loop{_, current-visibility}, /exps(b))
+        ; Case 3: We find an Indexable. Attempt to index it.
+        (i:Indexable&IExp) : 
+          val name = name?(i, nm)
+          val info = info(i as IExp)
+          val kind = kindof(i)
+          ; Case 4a.: Successfully found info and name, yield
+          ; Case 4b.: (implicit) If name or info is not found, skip.
+          match(info:FileInfo, name:Symbol) : 
+            yield(Indexed(kind, current-visibility, name, info))
+        ; Case 5: We encounter an IExp we can't index. Skip.
+        (e:?) :
+          false ; do nothing
+    ; launch!
+    do(loop{_, Private}, exps)
 
-;============================================================
-;============================================================
-;============================================================
-public defmulti kindof (e) -> SrcDefinitionKind
-public defmethod kindof (e): 
-  SrcDefUnknown
+; Helper to extract definitions from DL-IR pulled out of .pkg and .fpkg files.
+defn collect-definitions (packageio:PackageIO) -> Seq<Definition> :
+  for e in filter({info(_) is-not False}, exports(packageio)) seq :
+    Definition(name, info, kind, source, package, visibility) where :
+      val name       = name(id(rec(e)))
+      val info       = info(e) as FileInfo
+      val package    = package(packageio)
+      val visibility = visibility(e)
+      val source     = PkgDefinition
+      val kind       = SrcDefUnknown
 
-public defmethod kindof (e:IDefmulti): 
-  SrcDefMulti
+; A helper multi to handle the following cases : 
+; - Indexing of source code
+; - Indexing of .pkg files
+; - Indexing of .fpkg files
+protected defmulti index-definitions (pkg, nm:NameMap) -> Seq<Definition>
 
-public defmethod kindof (e:IDefmethod|ILSDefmethod): 
-  SrcDefMethod
+; Index a package from source code. First index the expressions, then convert to a `Definition`
+; object that can be serialized.
+protected defmethod index-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> :
+  val indexed-exps = index-expressions(exps(ipackage), nm)
+  for indexed in indexed-exps seq : 
+    Definition(name, info, kind, source, package, visibility) where : 
+      val package    = name(ipackage)
+      val name       = name(indexed)
+      val info       = info(indexed)
+      val kind       = kind(indexed)
+      val source     = SrcDefinition
+      val visibility = visibility(indexed)
 
-public defmethod kindof (e:IDefn|ILSDefn): 
-  SrcDefFunction
+; Index a package from a .fpkg file.
+defmethod index-definitions (pkg:FastPkg, nm:NameMap) -> Seq<Definition> :
+  collect-definitions(packageio(pkg))
 
-public defmethod kindof (e:IDefType|ILSDefType): 
-  SrcDefType
+; Index a package from a .pkg file.
+defmethod index-definitions (pkg:StdPkg, nm:NameMap) -> Seq<Definition> :
+  collect-definitions(packageio(vmp(pkg)))
 
-defstruct DefRec :
-  name: Symbol
-  info: FileInfo
-
-defmulti public-definitions (pkg:IPackage|Pkg, nm:NameMap) -> Seq<Definition>
-
-defn lookup (nm:NameMap, e:IExp) -> False|Symbol :
-  match(e:VarN) : name(nm[n(e)])
-  else: false
-
-;find all public definitions in ipackage
-defmethod public-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> :
-  val exps = generate<IExp> :
-    defn loop (e:IExp) :
-      defn* loop-public (e:IExp, public?:True|False) :
-        match(e) :
-          (e:IBegin) :
-            do(loop-public{_, public?}, exps(e))
-          (e:IDefn|IDef|IDefChild|IDefType|IDefVar|IDefmulti|IDefmethod|ILSDefn|ILSDefType|ILSDefmethod|IDoc) :
-            yield(e)
-          (e:IVisibility) :
-            loop-public(exp(e), visibility(e) is Public)
-          (e) :
-            false
-      match(e) :
-        (e:IBegin) :
-          do(loop, exps(e))
-        (e:IDoc) :
-          yield(e)
-        (e:IDefmethod|ILSDefmethod) :
-          yield(e)
-        (e:IVisibility) :
-          loop-public(exp(e), visibility(e) is Public)
-        (e) :
-          false
-    for e in exps(ipackage) do :
-      loop(e)
-  generate<Definition> :
-    for exp in exps do :
-      defn add-def (e-name:IExp, info:False|FileInfo) :
-        match(info:FileInfo) :
-          match(lookup(nm, e-name)) :
-            (e-name:Symbol) : 
-              yield $ Definition(e-name, info, kindof(exp), SrcDefinition, name(ipackage))
-            (o) : false
-      match(exp) :
-        (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti) :
-          add-def(name(e), info(e))
-        (e:IDefType) :
-          add-def(class(e), info(e))
-        (e:ILSDefmethod|IDefmethod) :
-          add-def(multi(e), info(e))
-        (e) :
-          false
-    
-defn collect-public-definitions (packageio:PackageIO) -> Seq<Definition> :
-  generate<Definition> :
-    defn add-def (name:Symbol, info:False|FileInfo) :
-      match(info:FileInfo) : 
-        yield $ Definition(name, info, SrcDefUnknown, PkgDefinition, package(packageio))
-
-    for e in exports(packageio) do :
-      if visibility(e) is Public :
-        add-def(name(id(rec(e))), info(e))
-
-defmethod public-definitions (pkg:FastPkg, nm:NameMap) -> Seq<Definition> :
-  collect-public-definitions(packageio(pkg))
-
-defmethod public-definitions (pkg:StdPkg, nm:NameMap) -> Seq<Definition> :
-  collect-public-definitions(packageio(vmp(pkg)))
-
+; A list of keywords in stanza.
 val stanza-reserved-words = [
   "package" "import" "prefix-of" "prefix" "public" "protected" "private" "doc" "deftype" "defchild" "def"
   "defpackage" "defvar" "defn" "defn*" "defmulti" "defmethod" "defmethod*" "fn" "fn*"
@@ -171,19 +200,88 @@ val stanza-reserved-words = [
   "?" "of" "ptr" "ref"
   ]
 
-public defn gen-defs-db (
-  out-path: String, 
-  name-map:    NameMap,
-  packages: Seqable<IPackage|Pkg>
-):
+; Create the definitions database by indexing definitions and packages
+protected defn create-defs-db (name-map:NameMap, packages:Seqable<IPackage|Pkg>) -> DefinitionsDatabase : 
   val all-definitions = HashTable<Symbol, List<Definition>>(List())
-  for package in packages do : 
-    val definitions = to-tuple $ public-definitions(package, name-map)
+  val all-packages = Vector<PackageDefinition>()
+  
+  for package in packages do :
+    match(package:IPackage) : 
+      add(all-packages, PackageDefinition(name, file-name, imports)) where : 
+        val name      = name(package)
+        val file-name = if-false?("NoFile", call?(filename, info(package)))
+        val imports   = []
+    
+    val definitions = index-definitions(package, name-map)
     for def in definitions do : 
       val name = name(def)
       update(all-definitions, cons{def, _}, name)
-  val ddb = DefinitionsDatabase(stanza-reserved-words, all-definitions)
-  val ostream = FileOutputStream(out-path)
-  serialize(ostream, ddb)
-  close(ostream)
   
+  DefinitionsDatabase(reserved-words, definitions, packages) where : 
+    val reserved-words = stanza-reserved-words
+    val definitions = all-definitions
+    val packages = to-tuple(all-packages)
+
+public defn gen-defs-db (out-path:String, 
+                         name-map:NameMap,
+                         packages:Seqable<IPackage|Pkg>) :
+  val ostream = FileOutputStream(out-path)
+  val defs = create-defs-db(name-map, packages)
+  serialize(ostream, defs)
+  close(ostream)
+
+;==============================================================================
+;================================ Helpers =====================================
+;==============================================================================
+; Report the "kind" of an IExp 
+public defn kindof (e:IExp) : 
+  match(e) : 
+    (e:IDefmulti) : 
+      SrcDefMulti
+    (e:IDefmethod|ILSDefmethod) : 
+      SrcDefMethod
+    (e:IDefn|ILSDefn) : 
+      SrcDefFunction
+    (e:IDefType|ILSDefType) : 
+      SrcDefType
+    (e:?) : 
+      SrcDefUnknown
+
+; Retrieve the name of an expression from the Name map, if it exists
+defn lookup (nm:NameMap, e:IExp) -> False|Symbol :
+  match(e:VarN) : 
+    name(nm[n(e)])
+
+; Lookup the name of an Indexable from the name map.
+defn name? (i:Indexable, nm:NameMap) -> False|Symbol :
+  val exp-name = 
+    match(i) : 
+      (e:ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti|IDefChild) : 
+        name(e)
+      (e:IDefType) : 
+        class(e)
+      (e:IDefmethod|ILSDefmethod) : 
+        multi(e)
+  lookup(nm, exp-name)
+
+; call `f` if `x` is False, otherwise return false
+defn call?<?T, ?U> (f: T -> ?U, x:?T|False) -> U|False : 
+  false when x is False else f(x as T)
+
+; return `value` if x is false, else return x
+defn if-false?<?T> (value:?T, x:?T|False) -> T : 
+  value when x is False else x as T
+
+; Index entries are `Equalable` for testing.
+defmethod equal? (l:Indexed, r:Indexed) :
+  kind(l) == kind(r) and 
+  visibility(l) == visibility(r) and 
+  name(l) == name(r) and 
+  info(l) == info(r)
+
+;============================================================
+;============= Retrieve All Packages in Proj File ===========
+;============================================================
+defn all-packages (proj-file:ProjFile) -> Tuple<Symbol> :
+  val defined = filter-by<DefinedInStmt>(stmts(proj-file))
+  to-tuple(seq(package, defined))

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -21,7 +21,7 @@ defpackage stz/defs-db :
 ;============================================================
 public defstruct DefsDbInput :
   proj-files: Tuple<String>
-  platform: Symbol|False
+  platform: Symbol
   flags: Tuple<Symbol>
   optimize?: True|False
 
@@ -37,15 +37,8 @@ public defn defs-db (input:DefsDbInput, filename:String) :
 
 ; Helper function to compile the input data into IL-IR.
 protected defn compile-input (input:DefsDbInput) -> [NameMap, Seqable<IPackage|Pkg>] :
-  ;Compute platform
-  read-config-file()
-  val db-platform = 
-    match(platform(input)) : 
-      (s:Symbol) : s
-      (f:False)  : OUTPUT-PLATFORM
-  
   ;Read all listed packages from given project files
-  val proj-file = read-proj-files(proj-files(input), db-platform)
+  val proj-file = read-proj-files(proj-files(input), platform(input))
   val input-packages = all-packages(proj-file)
   val proj-files-and-packages = to-tuple $
     cat(proj-files(input), input-packages)
@@ -54,7 +47,7 @@ protected defn compile-input (input:DefsDbInput) -> [NameMap, Seqable<IPackage|P
   val build-settings = BuildSettings(
     BuildPackages(proj-files-and-packages), ;inputs
     [],                                     ;vm-packages
-    db-platform,                            ;platform
+    platform(input),                        ;platform
     false,                                  ;assembly
     false,                                  ;output
     false,                                  ;external dependencies
@@ -120,8 +113,7 @@ deftype Indexable :
 ; - If an `Indexable`'s name cannot be found, it is skipped 
 ;
 protected defn index-expressions (exps:Seqable<IExp>, nm:NameMap) -> Seq<Indexed> :
-  var print? = false
-  generate : 
+  generate<Indexed> : 
     defn loop (e:IExp, current-visibility:Visibility) :
       match(e) : 
         ; Case 1: We encounter a visibility node. Walk its
@@ -166,7 +158,7 @@ protected defmulti index-definitions (pkg, nm:NameMap) -> Seq<Definition>
 
 ; Index a package from source code. First index the expressions, then convert to a `Definition`
 ; object that can be serialized.
-protected defmethod index-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> :
+defmethod index-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> :
   val indexed-exps = index-expressions(exps(ipackage), nm)
   for indexed in indexed-exps seq : 
     Definition(name, info, kind, source, package, visibility) where : 
@@ -184,6 +176,19 @@ defmethod index-definitions (pkg:FastPkg, nm:NameMap) -> Seq<Definition> :
 ; Index a package from a .pkg file.
 defmethod index-definitions (pkg:StdPkg, nm:NameMap) -> Seq<Definition> :
   collect-definitions(packageio(vmp(pkg)))
+
+; Index a PackageDefinition from an IPackage node.  
+protected defn index-package (ipackage:IPackage) -> PackageDefinition : 
+  PackageDefinition(name, file-name, imports) where : 
+    val name      = name(ipackage)
+    val file-name = if-false?("NoFile", call?(filename, info(ipackage)))
+    val imports   =
+      for iimport in imports(ipackage) map :
+        PackageImport(name, prefixes) where : 
+          val name = package(iimport)
+          val prefixes = 
+            for iprefix in prefix(iimport) map : 
+              PackageImportPrefix(names(iprefix), prefix(iprefix))
 
 ; A list of keywords in stanza.
 val stanza-reserved-words = [
@@ -206,11 +211,8 @@ protected defn create-defs-db (name-map:NameMap, packages:Seqable<IPackage|Pkg>)
   
   for package in packages do :
     match(package:IPackage) : 
-      add(all-packages, PackageDefinition(name, file-name, imports)) where : 
-        val name      = name(package)
-        val file-name = if-false?("NoFile", call?(filename, info(package)))
-        val imports   = []
-    
+      add(all-packages, index-package(package))
+
     val definitions = index-definitions(package, name-map)
     for def in definitions do : 
       val name = name(def)

--- a/compiler/stz-dl-ir.stanza
+++ b/compiler/stz-dl-ir.stanza
@@ -449,12 +449,6 @@ public defn n (iotable:IOTable, id:RecId) :
 ;========================= Printer ==========================
 ;============================================================
 
-defmethod print (o:OutputStream, v:Visibility) :
-  print{o, _} $ match(v) :
-    (v:Private) : "private"
-    (v:Protected) : "protected"
-    (v:Public) : "public"
-
 defmethod print (o:OutputStream, t:DType) :
   print{o, _} $ match(t) :
     (t:DByte) : "byte"
@@ -605,9 +599,9 @@ defsyntax dl-ir :
   defrule dtvar = (?x) when prefix-id?(x,"TV") : DTVar(id-prefix(closest-info(), x, 2))
 
   defproduction vis : Visibility
-  defrule vis = (private) : Private()
-  defrule vis = (protected) : Protected()
-  defrule vis = (public) : Public()
+  defrule vis = (private) : Private
+  defrule vis = (protected) : Protected
+  defrule vis = (public) : Public
 
   defproduction vid : ValId
   defrule vid = (V(?p:#symbol,?n:#symbol)) : ValId(p,n)

--- a/compiler/stz-input.stanza
+++ b/compiler/stz-input.stanza
@@ -74,13 +74,13 @@ defn ls-name-args (e:IExp) -> [IExp, List<IExp>] :
          IPrefixExp(false, p, info)
       ($public e:e es:e ...) :
          val es* = Begin(e, es, info)
-         IVisibility(es*, Public(), info)
+         IVisibility(es*, Public, info)
       ($protected e:e es:e ...) :
          val es* = Begin(e, es, info)
-         IVisibility(es*, Protected(), info)
+         IVisibility(es*, Protected, info)
       ($private e:e es:e ...) :
          val es* = Begin(e, es, info)
-         IVisibility(es*, Private(), info)
+         IVisibility(es*, Private, info)
       ;Stanza Declaration Forms
       ($doc string:e) :
         IDoc(string, info)

--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -842,13 +842,14 @@ defn defs-db-command () :
   in conjunction with the Stanza language server."
   defn defs-db-action (cmd-args:CommandArgs) :
     defn main () :
+      read-config-file()
       val output = cmd-args["o"]
       defs-db(db-input(), output)
 
     defn db-input () -> DefsDbInput :
       DefsDbInput(
         args(cmd-args),                               ;proj-files
-        false
+        OUTPUT-PLATFORM,
         map(to-symbol, get?(cmd-args, "flags", [])),  ;flags
         flag?(cmd-args, "optimize"))                  ;optimize?   
 

--- a/compiler/stz-pkg.stanza
+++ b/compiler/stz-pkg.stanza
@@ -374,10 +374,11 @@ defserializer (out:FileOutputStream, in:FileInputStream) :
   defunion dimport (Import) :
     Import: (n:int, rec:drec, transient?:bool)
 
-  defunion visibility (Visibility) :
-    Private: ()
-    Protected: ()
-    Public: ()
+  reader defn read-visibility () : 
+    Visibility(read-int())
+
+  writer defn write-visibility (v:Visibility) : 
+    write-int(to-int(v))
 
   ;================
   ;==== DTypes ====

--- a/compiler/stz-renamer.stanza
+++ b/compiler/stz-renamer.stanza
@@ -224,7 +224,7 @@ defn Engine (package:Symbol) :
     ;Top level starts as a recursive group
     push-group(e)
     ;Top level definitions are private by default
-    push-visibility(e, Private())
+    push-visibility(e, Private)
     e
 
   initialize $ new Engine :

--- a/compiler/stz-tl-to-dl.stanza
+++ b/compiler/stz-tl-to-dl.stanza
@@ -106,7 +106,7 @@ defn compute-exports (p:TPackage, namemap:NameMap) :
         val e = namemap[n]
         [visibility(e), info(e)]
       else :
-        [Private(), false]
+        [Private, false]
     add(exports, Export(n, vis, r, info))
     
   for c in comms(p) do :

--- a/compiler/stz-visibility.stanza
+++ b/compiler/stz-visibility.stanza
@@ -1,5 +1,12 @@
-defpackage stz/visibility
-public deftype Visibility
-public defstruct Private <: Visibility
-public defstruct Protected <: Visibility
-public defstruct Public <: Visibility
+defpackage stz/visibility :
+  import core
+
+public defenum Visibility : 
+  Private
+  Protected
+  Public
+
+; public deftype Visibility
+; public defstruct Private <: Visibility
+; public defstruct Protected <: Visibility
+; public defstruct Public <: Visibility

--- a/tests/indexing-data/stanza.proj
+++ b/tests/indexing-data/stanza.proj
@@ -1,0 +1,1 @@
+package test-package defined-in "test-package.stanza"

--- a/tests/indexing-data/test-package.stanza
+++ b/tests/indexing-data/test-package.stanza
@@ -1,0 +1,11 @@
+defpackage test-package :
+  import core
+  import collections
+
+public defn public-fn () -> Int : 0
+protected defn protected-fn () -> Int : 0
+defn private-fn () -> Int : 0
+
+public deftype PublicType
+protected deftype ProtectedType
+deftype PrivateType

--- a/tests/stanza.proj
+++ b/tests/stanza.proj
@@ -6,7 +6,7 @@ package stz/test-utils defined-in "test-utils.stanza"
 package stz/test-trampoline defined-in "test-trampoline.stanza"
 package stz/test-paths defined-in "test-paths.stanza"
 package stz/test-dispatch-dag defined-in "test-dispatch-dag.stanza"
-package stz/test-definitions-database defined-in "test-definitions-database"
+package stz/test-definitions-database defined-in "test-definitions-database.stanza"
 
 ;Post-compilation tests
 ;First the compiler under development needs to be compiled

--- a/tests/stanza.proj
+++ b/tests/stanza.proj
@@ -6,6 +6,7 @@ package stz/test-utils defined-in "test-utils.stanza"
 package stz/test-trampoline defined-in "test-trampoline.stanza"
 package stz/test-paths defined-in "test-paths.stanza"
 package stz/test-dispatch-dag defined-in "test-dispatch-dag.stanza"
+package stz/test-definitions-database defined-in "test-definitions-database"
 
 ;Post-compilation tests
 ;First the compiler under development needs to be compiled

--- a/tests/test-definitions-database.stanza
+++ b/tests/test-definitions-database.stanza
@@ -1,0 +1,101 @@
+#use-added-syntax(tests)
+defpackage stz/test-definitions-database : 
+  import core
+  import collections
+  import stz/defs-db
+  import stz/defs-db-serializer
+  import stz/il-ir
+  import stz/visibility
+
+
+; Helper function to compile a test file into IL-IR
+defn input-ir () : 
+  stz/defs-db/compile-input $
+    DefsDbInput(proj-files, platform, flags, optimize?) where : 
+      val proj-files = ["tests/indexing-data/stanza.proj"]
+      val platform   = `linux
+      val flags      = []
+      val optimize?  = false
+
+; Helper fucntion to create a FileInfo for the test source file.
+defn test-info (line:Int, column:Int) : 
+  FileInfo("tests/indexing-data/test-package.stanza", line, column)
+
+; Here, we test to make sure the indexing algorithm works as expected 
+; on the test input data. 
+deftest test-indexing-of-iexps : 
+  val [namemap, packages] = input-ir()
+  val ipackages = filter-by<IPackage>(packages)
+  val test-package = 
+    for pkg in ipackages find! : 
+      name(pkg) == `test-package
+  
+  val indexed = to-tuple $ stz/defs-db/index-expressions(exps(test-package), namemap)
+  defn lookup? (name:Symbol) : 
+    find({stz/defs-db/name(_) == name}, indexed)
+  
+  #EXPECT(lookup?(`public-fn)     == stz/defs-db/Indexed(SrcDefFunction, Public,    `public-fn,     test-info(5, 12)))
+  #EXPECT(lookup?(`protected-fn)  == stz/defs-db/Indexed(SrcDefFunction, Protected, `protected-fn,  test-info(6, 15)))
+  #EXPECT(lookup?(`private-fn)    == stz/defs-db/Indexed(SrcDefFunction, Private,   `private-fn,    test-info(7, 5)))
+  #EXPECT(lookup?(`PublicType)    == stz/defs-db/Indexed(SrcDefType,     Public,    `PublicType,    test-info(9, 15)))
+  #EXPECT(lookup?(`ProtectedType) == stz/defs-db/Indexed(SrcDefType,     Protected, `ProtectedType, test-info(10, 18)))
+  #EXPECT(lookup?(`PrivateType)   == stz/defs-db/Indexed(SrcDefType,     Private,   `PrivateType,   test-info(11, 8)))
+
+; Here, we test that the indexing algorithm correctly associates definitions with their source package.
+deftest test-indexing-to-definitions : 
+  val [namemap, packages] = input-ir()
+  val ipackages = filter-by<IPackage>(packages)
+  val test-package = 
+    for pkg in ipackages find! : 
+      name(pkg) == `test-package
+  
+  val definitions = to-tuple $ stz/defs-db/index-definitions(test-package, namemap)
+  defn test (name:Symbol) : 
+    val def = find({/name(_) == name}, definitions)
+    match(def:Definition) :
+      #EXPECT(source(def)  == SrcDefinition)
+      #EXPECT(pkg-name(def) == /name(test-package))
+    else : 
+      println("Could not lookup %_ in indexed definitions." % [name])
+      #EXPECT(false)
+  
+  val symbols = [
+    `public-fn
+    `protected-fn
+    `private-fn
+    `PublicType
+    `ProtectedType
+    `PrivateType
+  ]
+
+  do(test, symbols)
+
+; A test to check if the serializer and deserializer for the DefinitionsDatabase
+; object runs correctly and returns a table of definitions which match the 
+; definitions we provide.
+deftest test-serde-of-definitions-database : 
+  val [namemap, packages] = input-ir()
+  val ipackages = filter-by<IPackage>(packages)
+  val test-package = 
+    for pkg in ipackages find! : 
+      name(pkg) == `test-package
+  
+  val definitions = to-tuple $ stz/defs-db/index-definitions(test-package, namemap)
+  val database = stz/defs-db/create-defs-db(namemap, [test-package])
+
+  let : 
+    val file = FileOutputStream("test-ddb.dat")
+    serialize(file, database)
+    close(file)
+  
+  let : 
+    val file = FileInputStream("test-ddb.dat")
+    val deserialized = read-definitions-database(file)
+    for kv in /definitions(deserialized) do : 
+      val matching = find!({key(kv) == name(_)}, definitions)
+      #EXPECT(matching == head $ value(kv))
+      
+    close(file)
+  
+  if file-exists?("test-ddb.dat") : 
+    delete-file("test-ddb.dat")


### PR DESCRIPTION
- Added support for visibility modifiers in the definitions database
- Altered algorithm to flatten IL-IR into definitions and their visibility
- Split indexing functions into helpers to make it easier to test
- Added unit tests to check each step of the indexing process.