### PR TITLE
Fix naming for stz/test-bitset-intrinsics

### DIFF
--- a/tests/stanza.proj
+++ b/tests/stanza.proj
@@ -8,6 +8,7 @@ package stz/test-paths defined-in "test-paths.stanza"
 package stz/test-dispatch-dag defined-in "test-dispatch-dag.stanza"
 package stz/test-packed-class-table defined-in "test-packed-class-table.stanza"
 package stz/test-definitions-database defined-in "test-definitions-database.stanza"
+package stz/test-bitset-intrinsics defined-in "test-bitset-intrinsics.stanza"
 
 ;Post-compilation tests
 ;First the compiler under development needs to be compiled

--- a/tests/test-bitset-intrinsics.stanza
+++ b/tests/test-bitset-intrinsics.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(tests)
-defpackage test-bitset-intrinsics :
+defpackage stz/test-bitset-intrinsics :
   import core
   import collections
 


### PR DESCRIPTION
Fix for
```
stanza run-test build-stanza.proj tests/stanza.proj stz/stanza-tests
```
```
tests/stanza-tests.stanza:10.9: Could not find package stz/test-bitset-intrinsics, which is imported
by package stz/stanza-tests.
```