### PR TITLE
Fix tests/test-trampoline for linux

### DIFF
--- a/tests/test-trampoline.stanza
+++ b/tests/test-trampoline.stanza
@@ -65,7 +65,7 @@ deftest test-stanza-trampoline :
     assert-cmd-returns("./build/call-osx-trampoline", TRAMPOLINE-RESULT)
   #else :
     #if-defined(PLATFORM-LINUX) :
-      cmd $ "gcc build/osx-trampoline.s tests/call-trampoline.c -o build/call-linux-trampoline -DPLATFORM_LINUX"
+      cmd $ "gcc build/linux-trampoline.s tests/call-trampoline.c -o build/call-linux-trampoline -DPLATFORM_LINUX"
       assert-cmd-returns("./build/call-linux-trampoline", TRAMPOLINE-RESULT)
     #else :
       #if-defined(PLATFORM-WINDOWS) :


### PR DESCRIPTION
Fixes incorrect source for tests/test-trampoline.stanza on linux
```
stanza run-test build-stanza.proj tests/stanza.proj stz/test-trampoline
```
```
[Test 1] test-stanza-trampoline 
Build trampoline code
Execute trampoline code
/usr/bin/ld: /tmp/ccC8FzIn.o: in function `call1':
call-trampoline.c:(.text+0x6e9): undefined reference to `c_trampoline'
/usr/bin/ld: /tmp/ccC8FzIn.o: in function `call2':
call-trampoline.c:(.text+0x79f): undefined reference to `c_trampoline'
/usr/bin/ld: /tmp/ccC8FzIn.o: in function `call3':
call-trampoline.c:(.text+0xa88): undefined reference to `c_trampoline'
/usr/bin/ld: /tmp/ccC8FzIn.o: in function `call4':
call-trampoline.c:(.text+0xb4b): undefined reference to `c_trampoline'
collect2: error: ld returned 1 exit status
[FAIL]
  Uncaught Exception: No such file or directory
    in core/print-stack-trace
      at core/core.stanza:329.14
```