### PR TITLE
Added annotations to definitions database

### DIFF
--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -31,6 +31,7 @@ public defstruct Definition <: Equalable :
   source:SrcDefinitionSource
   pkg-name:Symbol
   visibility:Visibility
+  annotation?:False|DefinitionAnnotation
 
 doc: "A collection of definitions and reserved words in a stanza project"
 public defstruct DefinitionsDatabase : 
@@ -38,18 +39,36 @@ public defstruct DefinitionsDatabase :
   definitions:HashTable<Symbol, List<Definition>>
   packages:Tuple<PackageDefinition>
 
+doc: "A definition of a package and its imports."
 public defstruct PackageDefinition : 
   name:Symbol
   file-name:String
   imports:Tuple<PackageImport>
 
+doc: "An imported package and its prefixes."
 public defstruct PackageImport : 
   name:Symbol
   prefixes:Tuple<PackageImportPrefix>
 
+doc: "A prefix in a package import."
 public defstruct PackageImportPrefix : 
   names:False|Tuple<Symbol>
   prefix:String
+
+doc: "A DefinitionAnnotation is some definition-specific \
+      metadata that is useful for tooling, for example   \
+      function signatures."
+public deftype DefinitionAnnotation <: Equalable
+
+doc: "Annotations given to defn objects."
+public defstruct DefnAnnotation <: DefinitionAnnotation :
+  args:Tuple<FnArgAnnotation>
+  return-type?:Symbol|False
+
+doc: "A single function argument."
+public defstruct FnArgAnnotation <: Equalable :
+  name:Symbol
+  type?:Symbol|False
 
 ;===============================================================================
 ; =========================== Serializers =====================================
@@ -59,7 +78,7 @@ public defserializer (out:OutputStream, in:InputStream) :
     DefinitionsDatabase : (reserved-words:tuple(string), definitions:table, packages:tuple(package-definition))
 
   defunion definition (Definition) : 
-    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src, pkg-name:symbol, visibility:visibility)
+    Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind, source:src-def-src, pkg-name:symbol, visibility:visibility, annotation?:opt<DefinitionAnnotation>(annotation))
   
   defunion package-definition (PackageDefinition) : 
     PackageDefinition : (name:symbol, file-name:string, imports:tuple(package-import))
@@ -72,6 +91,12 @@ public defserializer (out:OutputStream, in:InputStream) :
   
   defunion fileinfo (FileInfo) :
     FileInfo : (filename:string, line:int, column:int)
+
+  defunion fn-arg-annotation (FnArgAnnotation) : 
+    FnArgAnnotation : (name:symbol, type?:opt<Symbol>(symbol))
+  
+  defunion annotation (DefinitionAnnotation) : 
+    DefnAnnotation : (args:tuple(fn-arg-annotation), return-type?:opt<Symbol>(symbol))
 
   reader defn read-visibility () : 
     Visibility(read-int())
@@ -212,12 +237,22 @@ defn from-var-int (N: () -> Byte) -> Int :
     else : to-int(x)
 
 defmethod equal? (l:Definition, r:Definition) :
-  name(l)       == name(r)      and 
-  file-info(l)  == file-info(r) and  
-  kind(l)       == kind(r)      and  
-  source(l)     == source(r)    and 
-  pkg-name(l)   == pkg-name(r)  and 
-  visibility(l) == visibility(r)
+  name(l)        == name(r)       and 
+  file-info(l)   == file-info(r)  and  
+  kind(l)        == kind(r)       and  
+  source(l)      == source(r)     and 
+  pkg-name(l)    == pkg-name(r)   and 
+  visibility(l)  == visibility(r) and
+  annotation?(l) == annotation?(r)
+
+defmethod equal? (l:DefnAnnotation, r:DefnAnnotation) : 
+  return-type?(l) == return-type?(r) and 
+  for (larg in args(l), rarg in args(r)) all? : 
+    larg == rarg
+
+defmethod equal? (l:FnArgAnnotation, r:FnArgAnnotation) : 
+  name(l) == name(r) and 
+  type?(l) == type?(r)
 
 ;===============================================================================
 ;============================== Printers =======================================
@@ -229,6 +264,7 @@ defmethod print (o:OutputStream, def:Definition):
   lnprint(oo, "source: %_" % [source(def)])
   lnprint(oo, "pkg-name: %_" % [pkg-name(def)])
   lnprint(oo, "visibility: %_" % [visibility(def)])
+  lnprint(oo, "annotation?: %_" % [annotation?(def)])
 
 defmethod print (o:OutputStream, ddb:DefinitionsDatabase):
   val o2 = IndentedStream(o)
@@ -236,3 +272,15 @@ defmethod print (o:OutputStream, ddb:DefinitionsDatabase):
   do(lnprint{o2, _}, reserved-words(ddb))
   lnprint(o, "Definitions:")
   do(lnprint{o2, _}, definitions(ddb))
+
+defmethod print (o:OutputStream, a:FnArgAnnotation) : 
+  print(o, "$%_" % [name(a)])
+  val type? = type?(a)
+  match(type?:Symbol) : 
+    print(o, ":%_" % [type?])
+  
+defmethod print (o:OutputStream, f:DefnAnnotation) : 
+  print(o, "(%,)" % [args(f)])
+  val return-type? = return-type?(f)
+  match(return-type?:Symbol) : 
+    print(o, " -> %_" % [return-type?])

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -24,6 +24,8 @@ public defstruct DefsDbInput :
   platform: Symbol
   flags: Tuple<Symbol>
   optimize?: True|False
+with : 
+  printer => true
 
 ; Main entry point, given the input data and an output filename, 
 ; compile to IL-IR, create the definitions database, and serialize it 
@@ -78,6 +80,7 @@ protected defstruct Indexed <: Equalable :
   visibility:Visibility
   name:Symbol
   info:FileInfo
+  annotation?:False|DefinitionAnnotation
 with : 
   printer => true
 
@@ -85,6 +88,7 @@ with :
 ; structure. Currently supported are functions, multis, methods, types, and children
 ; in both Hi and Lo stanza.
 deftype Indexable :  
+  VarN         <: Indexable
   IDef         <: Indexable
   IDefn        <: Indexable
   IDefmulti    <: Indexable
@@ -129,10 +133,11 @@ protected defn index-expressions (exps:Seqable<IExp>, nm:NameMap) -> Seq<Indexed
           val name = name?(i, nm)
           val info = info(i as IExp)
           val kind = kindof(i)
+          val annotation? = annotate?(i, nm)
           ; Case 4a.: Successfully found info and name, yield
           ; Case 4b.: (implicit) If name or info is not found, skip.
           match(info:FileInfo, name:Symbol) : 
-            yield(Indexed(kind, current-visibility, name, info))
+            yield(Indexed(kind, current-visibility, name, info, annotation?))
         ; Case 5: We encounter an IExp we can't index. Skip.
         (e:?) :
           false ; do nothing
@@ -142,13 +147,31 @@ protected defn index-expressions (exps:Seqable<IExp>, nm:NameMap) -> Seq<Indexed
 ; Helper to extract definitions from DL-IR pulled out of .pkg and .fpkg files.
 defn collect-definitions (packageio:PackageIO) -> Seq<Definition> :
   for e in filter({info(_) is-not False}, exports(packageio)) seq :
-    Definition(name, info, kind, source, package, visibility) where :
-      val name       = name(id(rec(e)))
-      val info       = info(e) as FileInfo
-      val package    = package(packageio)
-      val visibility = visibility(e)
-      val source     = PkgDefinition
-      val kind       = SrcDefUnknown
+    Definition(name, info, kind, source, package, visibility, annotation?) where :
+      val name        = name(id(rec(e)))
+      val info        = info(e) as FileInfo
+      val package     = package(packageio)
+      val visibility  = visibility(e)
+      val source      = PkgDefinition
+      val kind        = kindof(rec(e))
+      val annotation? = false
+
+; Helper multi to create an annotation for an indexable  expression, if necessary.
+defmulti annotate? (exp:IExp&Indexable, nm:NameMap) -> False|DefinitionAnnotation : 
+  false
+
+defmethod annotate? (idefn:IDefn|IDefmethod|ILSDefn|ILSDefmethod, nm:NameMap) -> False|DefinitionAnnotation : 
+  DefnAnnotation(args, return-type?) where :  
+    val return-type? = stringify?(a2(idefn), nm)
+    val args* = 
+      for (arg in args(idefn), type in a1(idefn)) seq : 
+        val arg-name = stringify?(arg, nm)
+        if arg-name is False : 
+          fatal("arg-name cannot be false: %_" % [info(idefn)])
+        val type-name = stringify?(type, nm)
+        match(arg-name:Symbol) :
+          FnArgAnnotation(arg-name as Symbol, type-name)
+    val args = to-tuple(filter-by<FnArgAnnotation>(args*))
 
 ; A helper multi to handle the following cases : 
 ; - Indexing of source code
@@ -160,14 +183,15 @@ protected defmulti index-definitions (pkg, nm:NameMap) -> Seq<Definition>
 ; object that can be serialized.
 defmethod index-definitions (ipackage:IPackage, nm:NameMap) -> Seq<Definition> :
   val indexed-exps = index-expressions(exps(ipackage), nm)
-  for indexed in indexed-exps seq : 
-    Definition(name, info, kind, source, package, visibility) where : 
+  for indexed in indexed-exps seq :  
+    Definition(name, info, kind, source, package, visibility, annotation) where : 
       val package    = name(ipackage)
       val name       = name(indexed)
       val info       = info(indexed)
       val kind       = kind(indexed)
       val source     = SrcDefinition
       val visibility = visibility(indexed)
+      val annotation = annotation?(indexed)
 
 ; Index a package from a .fpkg file.
 defmethod index-definitions (pkg:FastPkg, nm:NameMap) -> Seq<Definition> :
@@ -248,24 +272,83 @@ public defn kindof (e:IExp) :
     (e:?) : 
       SrcDefUnknown
 
-; Retrieve the name of an expression from the Name map, if it exists
-defn lookup (nm:NameMap, e:IExp) -> False|Symbol :
-  match(e:VarN) :
-    val n = n(e)
-    if key?(nm, n) :
-      name(nm[n])
+public defn kindof (r:Rec) : 
+  match(r) : 
+    (v:ValRec|ExternRec)   : SrcDefVariable
+    (f:FnRec|ExternFnRec)  : SrcDefFunction
+    (m:MultiRec)           : SrcDefMulti
+    (t:TypeRec|TypeDecl|StructRec) : SrcDefType
+    (r:?) : SrcDefUnknown
+
+; A helper multi that converts some IR that represents a named
+; "thing" (type, identifier, etc) into human readable text.
+defmulti stringify? (i, nm:NameMap) -> False|Symbol : 
+  false
+
+defmethod stringify? (e:VarN, nm:NameMap) : 
+  if key?(nm, n(e)) : 
+    name(nm[n(e)])
+
+defmethod stringify? (r:Raw, nm:NameMap) : 
+  stringify?(class(r), nm)
+
+defmethod stringify? (l:List, nm:NameMap) : 
+  to-symbol("(%,)" % [seq(stringify?{_, nm}, l)])
+
+defmethod stringify? (iof:IOf, nm:NameMap) : 
+  to-symbol("%_<%,>" % [class(iof),  seq(stringify?{_, nm}, args(iof))])
+
+defmethod stringify? (ior:IOr, nm:NameMap) : 
+  val l = stringify?(a(ior), nm)
+  val r = stringify?(b(ior), nm)
+  match(l:Symbol, r:Symbol) :
+    to-symbol("%_|%_" % [l, r])
+
+defmethod stringify? (iand:IAnd, nm:NameMap) :
+  val l = stringify?(a(iand), nm)
+  val r = stringify?(b(iand), nm)
+  match(l:Symbol, r:Symbol) :
+    to-symbol("%_&%_" % [l, r])
+
+defmethod stringify? (igrad:IGradual, nm:NameMap) :
+  `? 
+
+defmethod stringify? (inone:INone, nm:NameMap) :
+  false
+
+defmethod stringify? (iarrow:IArrow, nm:NameMap) : 
+  val l = stringify?(a1(iarrow), nm)
+  val r = stringify?(a2(iarrow), nm)
+  match(l:Symbol, r:Symbol) :
+    to-symbol("%_ -> %_" % [l, r])
+
+defmethod stringify? (ivoid:IVoid, nm:NameMap) :
+  `Void
+
+defmethod stringify? (icap:ICap, nm:NameMap) : 
+  val type = stringify?(name(icap), nm)
+  match(type:Symbol) :
+    to-symbol("?%_" % [type])
+
+defmethod stringify? (ituple:ITuple, nm:NameMap) : 
+  to-symbol("[%,]" % [seq(stringify?{_, nm}, exps(ituple))])
 
 ; Lookup the name of an Indexable from the name map.
-defn name? (i:Indexable, nm:NameMap) -> False|Symbol :
-  val exp-name = 
-    match(i) : 
+defn name? (i:Indexable&IExp, nm:NameMap) -> False|Symbol :
+  val exp-name =
+    match(i) :
+      (e:VarN) : e
       (e:IDef|ILSDef|ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti|IDefChild) : 
         name(e)
       (e:IDefType) : 
         class(e)
       (e:IDefmethod|ILSDefmethod) : 
-        multi(e)
-  lookup(nm, exp-name)
+        val name = multi(e)
+        match(name:Mix) :
+          head(exps(name))
+        else : 
+          name
+  stringify?(exp-name, nm)
 
 ; call `f` if `x` is False, otherwise return false
 defn call?<?T, ?U> (f: T -> ?U, x:?T|False) -> U|False : 

--- a/tests/indexing-data/test-package.stanza
+++ b/tests/indexing-data/test-package.stanza
@@ -9,3 +9,10 @@ defn private-fn () -> Int : 0
 public deftype PublicType
 protected deftype ProtectedType
 deftype PrivateType
+
+defn takes-fn-as-arg<?T> (body: (False) -> ?T, not-named) -> T : 
+  body()
+
+defmulti my-multi (arg) -> False
+defmethod my-multi (arg:Int) : 
+  println("Arg is an Int")

--- a/tests/test-definitions-database.stanza
+++ b/tests/test-definitions-database.stanza
@@ -7,7 +7,6 @@ defpackage stz/test-definitions-database :
   import stz/il-ir
   import stz/visibility
 
-
 ; Helper function to compile a test file into IL-IR
 defn input-ir () : 
   stz/defs-db/compile-input $
@@ -34,12 +33,12 @@ deftest test-indexing-of-iexps :
   defn lookup? (name:Symbol) : 
     find({stz/defs-db/name(_) == name}, indexed)
   
-  #EXPECT(lookup?(`public-fn)     == stz/defs-db/Indexed(SrcDefFunction, Public,    `public-fn,     test-info(5, 12)))
-  #EXPECT(lookup?(`protected-fn)  == stz/defs-db/Indexed(SrcDefFunction, Protected, `protected-fn,  test-info(6, 15)))
-  #EXPECT(lookup?(`private-fn)    == stz/defs-db/Indexed(SrcDefFunction, Private,   `private-fn,    test-info(7, 5)))
-  #EXPECT(lookup?(`PublicType)    == stz/defs-db/Indexed(SrcDefType,     Public,    `PublicType,    test-info(9, 15)))
-  #EXPECT(lookup?(`ProtectedType) == stz/defs-db/Indexed(SrcDefType,     Protected, `ProtectedType, test-info(10, 18)))
-  #EXPECT(lookup?(`PrivateType)   == stz/defs-db/Indexed(SrcDefType,     Private,   `PrivateType,   test-info(11, 8)))
+  #EXPECT(lookup?(`public-fn)     == stz/defs-db/Indexed(SrcDefFunction, Public,    `public-fn,     test-info(5, 12),  DefnAnnotation([], `Int)))
+  #EXPECT(lookup?(`protected-fn)  == stz/defs-db/Indexed(SrcDefFunction, Protected, `protected-fn,  test-info(6, 15),  DefnAnnotation([], `Int)))
+  #EXPECT(lookup?(`private-fn)    == stz/defs-db/Indexed(SrcDefFunction, Private,   `private-fn,    test-info(7, 5),   DefnAnnotation([], `Int)))
+  #EXPECT(lookup?(`PublicType)    == stz/defs-db/Indexed(SrcDefType,     Public,    `PublicType,    test-info(9, 15),  false))
+  #EXPECT(lookup?(`ProtectedType) == stz/defs-db/Indexed(SrcDefType,     Protected, `ProtectedType, test-info(10, 18), false))
+  #EXPECT(lookup?(`PrivateType)   == stz/defs-db/Indexed(SrcDefType,     Private,   `PrivateType,   test-info(11, 8),  false))
 
 ; Here, we test that the indexing algorithm correctly associates definitions with their source package.
 deftest test-indexing-to-definitions : 
@@ -99,3 +98,35 @@ deftest test-serde-of-definitions-database :
   
   if file-exists?("test-ddb.dat") : 
     delete-file("test-ddb.dat")
+
+; This tests a non-trivial annotation lookup, a function
+; with type parameters, a captured type argument, unnamed argument, 
+; function as an argument, and return type.
+deftest test-lookup-of-annotations :
+  val [namemap, packages] = input-ir()
+  val database = stz/defs-db/create-defs-db(namemap, packages)
+  
+  val all-defs = seq-cat({_}, values(definitions(database)))
+  val takes-fn-as-arg = find!({name(_) == `takes-fn-as-arg}, all-defs)
+
+  val annotation = annotation?(takes-fn-as-arg) as DefnAnnotation
+  defn has-arg? (def:Definition, arg:FnArgAnnotation) -> True|False : 
+    val found? = 
+      for annotation in args(annotation) find : 
+        name(annotation) == name(arg) and 
+        type?(annotation) == type?(arg)
+      found? is-not False
+
+  #EXPECT(has-arg?(takes-fn-as-arg, FnArgAnnotation(`body, `\|(False) -> ?T|)))
+  #EXPECT(has-arg?(takes-fn-as-arg, FnArgAnnotation(`not-named, false)))
+  #EXPECT(return-type?(annotation) == `T)
+
+; A larger test on a large stanza codebase to check that the indexing 
+; algorithms and serializers do not crash.
+deftest index-stanza-repository : 
+  val input = DefsDbInput(proj-files, platform, flags, optimize?) where : 
+    val proj-files = ["tests/stanza.proj", "core/stanza.proj", "compiler/stanza.proj"]
+    val platform   = `linux
+    val flags      = []
+    val optimize?  = false
+  defs-db(input, "stanza.defs.dat")


### PR DESCRIPTION
- Corrected indexing of `kind` values from indexed .pkg/.fpkg files
- Added additional doc strings to stz/defs-db-serializer types
- Added a new annotations field to support indexing of function signatures
- Implemented function signature indexing for defns, lostanza defns, defmethod, and lostanza defmethod