### PR TITLE
Fix a bug in skip-live

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1055,9 +1055,8 @@ public lostanza defn initialize-heap (heap:ptr<Heap>,
   ;Initialize the memory for the main heap.
   val heap-start = call-c clib/stz_memory_map(min-heap-size, max-heap-size)
   heap.start  = heap-start
-  heap.top = heap-start
   heap.old-objects-end = heap-start
-  heap.limit = heap.start + compute-nursery-size(heap)
+  set-limit(heap-start + compute-nursery-size(heap), heap)
   ;Initialize the memory for the heap's bitset.
   val min-bitset-size = round-up-to-whole-pages(bitset-size(min-heap-size))
   val max-bitset-size = round-up-to-whole-pages(bitset-size(max-heap-size))
@@ -1140,7 +1139,7 @@ public lostanza defn allocate-initial (heap:ptr<Heap>, tag:long, size:long) -> p
   top = top + sizeof(long)
   heap.top = top + size
   #if-not-defined(OPTIMIZE) :
-    if heap.top > heap-end(heap) :
+    if heap.top > heap.limit :
       fatal!("Cannot allocate an initial object.")
   return top
 
@@ -2074,8 +2073,6 @@ lostanza defn check-write-barrier-invariants! (p:ptr<long>, vms:ptr<VMState>) ->
 ;============================================================
 
 ;This is the mark-compact garbage collection algorithm for old objects.
-;In order to perform a full-heap collection, the driver should call this function
-;after setting heap.old-objects-end to heap.start.
 lostanza defn mark-compact (vms:ptr<VMState>) -> ref<False> :
   clear-mark(vms.heap.start, vms.heap.top, addr(vms.heap))
 
@@ -2324,40 +2321,33 @@ lostanza defn set-limit (limit:ptr<long>, heap:ptr<Heap>) -> ref<False> :
 ;After GC, returns the number of bytes that are now free to be allocated from the heap.
 public lostanza defn collect-garbage (allocation-size:long, vms:ptr<VMState>) -> long :
   ;High Level Algorithm:
-  ;1) Define our desired young-gen to have size:
-  ;    (young-gen-frac * heap-size) + allocation-size
-  ;2) First try using a partial GC to create space for the young-gen.
-  ;3) Then try using a full GC to create space for the young-gen.
-  ;4) Then try expanding the heap to both:
-  ;  - create space for the young-gen
-  ;  - ensure the desired heap occupancy.
+  ;1) Define our desired nursery to have size:
+  ;    (nursery-frac * heap-size) + allocation-size
+  ;2) First try a partial GC to recover space for the nursery.
+  ;3) If not enough space recovered, proceed with a full GC.
+  ;4) After full GC try expanding the heap to ensure the desired heap capacity.
 
   ;If we're attempting to allocate a larger object than can ever
   ;be held in the heap (even after expansion) then don't bother doing anything.
   val heap = addr(vms.heap)
   if allocation-size < heap.max-size :
 
-    ;Step 1. Defining the desired size of the nursery.
+    ;Step 1. Define the desired size of the nursery.
     val nursery-size = compute-nursery-size(allocation-size, heap)
+    ;Fail if we cannot possibly free enough space with a partial GC.
+    if nursery-size <= available-space(heap) :
 
-    ;Step 2. Try using a partial GC to create space.
-    ;Fail if we're explicitly requested to do a full GC.
-    if heap.old-objects-end != heap.start :
+      ;Step 2. Try the partial GC.
+      evacuate-nursery(vms)
 
-      ;Fail if we cannot possibly free enough space using a partial GC.
+      ;Fail if the partial GC didn't recover enough space.
       if nursery-size <= available-space(heap) :
-
-        ;Try the partial GC.
-        evacuate-nursery(vms)
-
-        ;Fail if the partial GC didn't recover enough space.
-        if nursery-size <= available-space(heap) :
-          ;Success! The partial GC recovered enough space for the nursery.
-          clear-remembered-set(heap)
-          set-limit(heap.old-objects-end + nursery-size, heap)
-          ;Return the space remaining
-          return heap.limit - heap.top
-        heap.limit = heap.top
+        ;Success! The partial GC recovered enough space for the nursery.
+        clear-remembered-set(heap)
+        set-limit(heap.old-objects-end + nursery-size, heap)
+        ;Return the space remaining
+        return heap.limit - heap.top
+      heap.limit = heap.top
 
     ;Step 3. Try using a full GC to create space.
     mark-compact(vms)


### PR DESCRIPTION
When preliminary check finds that partial GC cannot recover enough space for desired nursery size + allocation size., or  full GC is requested), `mark-compact` can be called for a heap with uninitialized area in the range from `old-objects-end` to `nursery-start`. In a very rare case when all old objects are live at this moment, and old objects end is moved to heap start, a scan for solid prefix can reach this area and try to decode garbage there. The fix is to eliminate a special mode of operation with old objects end set to heap start.

I can only reproduce this crash when setting desired max heap size below current heap size with `set-max-heap-size`.