### PR TITLE
Implement set-max-heap-size

### DIFF
--- a/compiler/cvm.c
+++ b/compiler/cvm.c
@@ -405,6 +405,7 @@ typedef struct{
   uint64_t* bitset;
   uint64_t* bitset_base;
   uint64_t size;
+  uint64_t size_limit;
   uint64_t max_size;
   uint64_t* marking_stack_start;
   uint64_t* marking_stack_bottom;

--- a/compiler/stz-codegen.stanza
+++ b/compiler/stz-codegen.stanza
@@ -55,6 +55,7 @@ public defstruct AsmStubs :
   heap-bitset: Int
   heap-bitset-base: Int
   heap-size:Int
+  heap-size-limit:Int
   heap-max-size:Int
   heap-old-objects-end:Int
   marking-stack-start: Int
@@ -106,6 +107,7 @@ public defn AsmStubs (backend:Backend) :
     next(id-counter)  ;heap-bitset:Int
     next(id-counter)  ;heap-bitset-base: Int
     next(id-counter)  ;heap-size:Int
+    next(id-counter)  ;heap-size-limit:Int
     next(id-counter)  ;heap-max-size:Int
     next(id-counter)  ;heap-old-objects-end:Int
     next(id-counter)  ;marking-stack-start: Int
@@ -163,6 +165,7 @@ val VMINIT-PACKET = VMInitPacket $ [
   VMInitField(`heap-bitset, heap-bitset)
   VMInitField(`heap-bitset-base, heap-bitset-base)
   VMInitField(`heap-size, heap-size)
+  VMInitField(`heap-size-limit, heap-size-limit)
   VMInitField(`heap-max-size, heap-max-size)
   VMInitField(`stacks-list, stacks-list)
   VMInitField(`trackers-list, trackers-list)
@@ -199,6 +202,7 @@ public defn compile-runtime-stubs (emitter:CodeEmitter, stubs:AsmStubs) :
   comment("heap-bitset = %_" % [heap-bitset(stubs)])
   comment("heap-bitset-base = %_" % [heap-bitset-base(stubs)])
   comment("heap-size = %_" % [heap-size(stubs)])
+  comment("heap-size-limit = %_" % [heap-size-limit(stubs)])
   comment("heap-max-size = %_" % [heap-max-size(stubs)])
   comment("heap-old-objects-end = %_" % [heap-old-objects-end(stubs)])
   comment("marking-stack-start = %_" % [marking-stack-start(stubs)])
@@ -274,6 +278,7 @@ public defn compile-entry-function (emitter:CodeEmitter, stubs:AsmStubs) :
     #L(heap-bitset)            #long()                        ;heap.bitset: ptr<long>
     #L(heap-bitset-base)       #long()                        ;heap.bitset-base: ptr<long>
     #L(heap-size)              #long()                        ;heap.size: long
+    #L(heap-size-limit)        #long()                        ;heap.size-limit: long
     #L(heap-max-size)          #long()                        ;heap.max-size: long
     #L(stacks-list)            #long()                        ;heap.stacks: ptr<Stack>
     #L(trackers-list)          #long()                        ;heap.liveness-trackers: ptr<LivenessTracker>

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -959,6 +959,8 @@ lostanza val BITS-IN-LONG:long = 1 << LOG-BITS-IN-LONG
 ;  bitset-base = bit-address(bit-index(null))
 ;  bitset-base = bitset - (start >> LOG-BITS-IN-LONG)
 ;- size is the current allocated size of the heap.
+;- size-limit is the limit on heap size imposed by set-max-heap-size.
+;    It cannot exceed max-size.
 ;- max-size is the maximum size that the heap can be expanded to.
 ;- compaction-start is the lowest moving object in collection area.
 protected lostanza deftype Heap :
@@ -971,6 +973,7 @@ protected lostanza deftype Heap :
   var bitset:ptr<long>
   var bitset-base:ptr<long>
   var size:long
+  var size-limit:long
   var max-size:long
 
   ;List of live Stacks in this heap.
@@ -1052,6 +1055,7 @@ public lostanza defn initialize-heap (heap:ptr<Heap>,
   heap.size = min-heap-size
   val max-heap-size = round-up-to-whole-pages(max-size)
   heap.max-size = max-heap-size
+  heap.size-limit = max-heap-size
   ;Initialize the memory for the main heap.
   val heap-start = call-c clib/stz_memory_map(min-heap-size, max-heap-size)
   heap.start  = heap-start
@@ -1129,6 +1133,20 @@ lostanza defn expand-heap (size:long, heap:ptr<Heap>) -> ref<False> :
   ;Record the new heap size
   heap.size = desired-heap-size
 
+  ;No meaningful return value.
+  return false
+
+lostanza defn shrink-heap (desired-size:long, heap:ptr<Heap>) -> ref<False> :
+  ;Resize the heap.
+  call-c clib/stz_memory_resize(heap.start, heap.size, desired-size)
+
+  ;Resize the bitset.
+  val current-bitset-size = round-up-to-whole-pages(bitset-size(heap.size))
+  val desired-bitset-size = round-up-to-whole-pages(bitset-size(desired-size))
+  if current-bitset-size > desired-bitset-size :
+    call-c clib/stz_memory_resize(heap.bitset, current-bitset-size, desired-bitset-size)
+  ;Record the new heap size
+  heap.size = desired-size
   ;No meaningful return value.
   return false
 
@@ -2366,7 +2384,7 @@ public lostanza defn collect-garbage (allocation-size:long, vms:ptr<VMState>) ->
     val used-heap = heap.top - heap.start + nursery-size
     val usage-ratio = used-heap as double / heap.size as double
     if usage-ratio > 0.5 :
-      expand-heap(min(heap.max-size, used-heap * 2), heap)
+      expand-heap(min(heap.size-limit, used-heap * 2), heap)
 
     ;We've done what we can.
     ;Promote all the old objects, and
@@ -3747,17 +3765,26 @@ public lostanza defn current-heap-size () -> ref<Long> :
   return new Long{vms.heap.size}
 
 public lostanza defn current-max-heap-size () -> ref<Long> :
-  return new Long{MAXIMUM-HEAP-SIZE}
-
-defn ensure-valid-max-heap-size (sz:Long) :
-  val cur-sz = current-heap-size()
-  if sz < cur-sz :
-    fatal("Cannot set heap size to %_ bytes which is smaller than the current heap size (%_ bytes)." % [
-      sz, cur-sz])
+  val vms:ptr<VMState> = call-prim flush-vm()
+  return new Long{vms.heap.size-limit}
 
 public lostanza defn set-max-heap-size (sz:ref<Long>) -> ref<False> :
-  ensure-valid-max-heap-size(sz)
-  MAXIMUM-HEAP-SIZE = round-up-to-whole-pages(sz.value)
+  val vms:ptr<VMState> = call-prim flush-vm()
+  val heap = addr(vms.heap)
+  ;Ensure size is in range [0, max-heap-size] and round it up to whole pages.
+  var desired-size:long = min(round-up-to-whole-pages(max(sz.value, 0L)), heap.max-size)
+  val heap-size = heap.size
+  if desired-size < heap-size :
+    ;Try to shrink the heap
+    mark-compact(vms)
+    val min-size = round-up-to-whole-pages(heap.old-objects-end - heap.start)
+    desired-size = max(desired-size, min-size)
+    if desired-size < heap-size :
+      shrink-heap(desired-size, heap)
+    val nursery-size = compute-nursery-size(heap)
+    set-limit(min(heap.old-objects-end + nursery-size, heap-end(heap)), heap)
+  heap.size-limit = desired-size
+  ;No meaningful return value
   return false
 
 ;============================================================

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -100,6 +100,7 @@ typedef struct{
   stz_byte* heap_bitset;
   stz_byte* heap_bitset_base;
   stz_long heap_size;
+  stz_long heap_size_limit;
   stz_long heap_max_size;
   Stack* stacks;
   void* trackers;
@@ -1094,6 +1095,7 @@ STANZA_API_FUNC int main (int argc, char* argv[]) {
   const stz_long max_heap_size = ROUND_UP_TO_WHOLE_PAGES(STZ_LONG(8) * 1024 * 1024 * 1024);
   init.heap_start = (stz_byte*)stz_memory_map(min_heap_size, max_heap_size);
   init.heap_max_size = max_heap_size;
+  init.heap_size_limit = max_heap_size;
   init.heap_size = min_heap_size;
   stz_long young_gen_size = 2 * 1024 * 1024;
   init.heap_limit = init.heap_start + young_gen_size;


### PR DESCRIPTION
Implementation of the forgotten function `set-max-heap-size`. The function can shrink and grow the heap size up to `MAXIMUM-HEAP-SIZE`. Logical space of `MAXIMUM-HEAP-SIZE` is allocated for the heap when it is created and cannot be later extended. Memory is only committed to this space when necessary and cannot exceed the limit set by `set-max-heap-size`.

Current value of `MAXIMUM-HEAP-SIZE` is 8 GB.