### PR TITLE
Fixes and tests for annotating complex function signatures

### DIFF
--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -291,3 +291,25 @@ defmethod print (o:OutputStream, f:DefnAnnotation) :
   val return-type? = return-type?(f)
   match(return-type?:Symbol) : 
     print(o, " -> %_" % [return-type?])
+
+defmethod print (o:OutputStream, p:PackageDefinition) : 
+  print(o, "PackageDefinition %_" % [name(p)])
+  val oo = IndentedStream(o)
+  lnprint(oo, "file-name: %~" % [file-name(p)])
+  lnprint(oo, "imports:")
+  val ooo = IndentedStream(o)
+  do(lnprint{ooo, _}, imports(p))
+
+defmethod print (o:OutputStream, p:PackageImport) : 
+  print(o, name(p))
+  if not empty?(prefixes(p)) : 
+    val oo = IndentedStream(o)
+    lnprint(oo, "prefixes:")
+    do(lnprint{oo, _}, prefixes(p))
+
+defmethod print (o:OutputStream, p:PackageImportPrefix) : 
+  match(names(p)) : 
+    (f:False) : 
+      print(o, prefix(p))
+    (n:Tuple<Symbol>) : 
+      print(o, "(%,) => %_" % [n, prefix(p)])

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -326,7 +326,7 @@ defmethod stringify? (dtype:DOf, nm:NameMap) :
   if empty?(targs(dtype)) : 
     name(id(dtype))
   else : 
-    to-symbol $ "%_<%,>" % [name(id(dtype)), object-type(targs(dtype))]     
+    to-symbol $ "%_<%,>" % [name(id(dtype)), seq(stringify?{_, nm}, targs(dtype))]     
   
 defmethod stringify? (dtype:DTVar, nm:NameMap) : 
   to-symbol $ "TV%_" % [index(dtype)]
@@ -347,7 +347,7 @@ defmethod stringify? (dtype:DBot, nm:NameMap) :
   `bot
 
 defmethod stringify? (dtype:DTuple, nm:NameMap) : 
-  to-symbol $ "[%,]" % [types(dtype)]
+  to-symbol $ "[%,]" % [seq(stringify?{_, nm}, types(dtype))]
 
 defmethod stringify? (dtype:DArrow, nm:NameMap) : 
   to-symbol $ "(%,) -> %_" % [
@@ -366,7 +366,7 @@ defmethod stringify? (l:List, nm:NameMap) :
   to-symbol("(%,)" % [seq(stringify?{_, nm}, l)])
 
 defmethod stringify? (iof:IOf, nm:NameMap) : 
-  to-symbol("%_<%,>" % [class(iof),  seq(stringify?{_, nm}, args(iof))])
+  to-symbol("%_<%,>" % [stringify?(class(iof), nm),  seq(stringify?{_, nm}, args(iof))])
 
 defmethod stringify? (ior:IOr, nm:NameMap) : 
   val l = stringify?(a(ior), nm)

--- a/tests/indexing-data/test-package.stanza
+++ b/tests/indexing-data/test-package.stanza
@@ -16,3 +16,35 @@ defn takes-fn-as-arg<?T> (body: (False) -> ?T, not-named) -> T :
 defmulti my-multi (arg) -> False
 defmethod my-multi (arg:Int) : 
   println("Arg is an Int")
+
+public defn to-chunks<?T> (s:Seqable<?T>, chunk-sz:Int) -> Seq<Tuple<T>> : 
+  val s* = to-seq(s)
+  generate :
+    while not empty?(s*) : 
+      yield $ to-tuple $ 
+        for (e in s*, n in 0 to chunk-sz) seq : 
+          e
+
+defn maps-equal?<?T> (lhs:?T, rhs:?T, map-functions:Tuple<(T -> Equalable)>) -> True|False :
+  all?({_0(lhs) == _0(rhs)}, map-functions)
+
+defn memoize*<T,?S> (f: (T, ((T, ?) -> S)) -> ?S) -> (T -> S) :
+  val table = HashTable<T,S>()
+  defn recurse (key:T, rec:((T, ?) -> S)) :
+    if not key?(table, key) :
+      val result = f(key, rec)
+      table[key] = result
+      result
+    else :
+      table[key]
+  fn (key:T) :
+    recurse(key, recurse)
+
+defn apply<?T0, ?T1, ?T2, ?R> (f: (T0, T1, T2) -> ?R, args:[?T0, ?T1, ?T2]) -> R :
+  val [a0, a1, a2] = args
+  f(a0, a1, a2)
+  
+defn tuple-zip<?A0, ?R0, ?A1, ?R1> (f:[A0 -> ?R0, A1 -> ?R1], args:[?A0, ?A1]) -> [R0, R1] :
+  val [f0, f1] = f
+  val [a0, a1] = args
+  [f0(a0), f1(a1)]

--- a/tests/test-definitions-database.stanza
+++ b/tests/test-definitions-database.stanza
@@ -127,22 +127,28 @@ deftest index-stanza-repository :
     val optimize?  = false
   defs-db(input, "stanza.defs.dat")
 
+; This test compiles the test package and checks that some functions defined
+; in core.pkg and test-package.stanza have correctly inferred function 
+; signature annotations once indexed in the DefinitionsDatabase.
 deftest test-annotated-pkg-defs : 
   val input = DefsDbInput(proj-files, platform, flags, optimize?) where : 
-    val proj-files = ["tests/stanza.proj"]
+    val proj-files = ["tests/indexing-data/stanza.proj"]
     val platform   = `linux
     val flags      = []
     val optimize?  = false
 
   val [name-map, packages] = stz/defs-db/compile-input(input)
-  val core-package =
-    for pkg in filter-by<FastPkg|StdPkg>(packages) find! : 
-      package(packageio(pkg)) == `core
+  val database = stz/defs-db/create-defs-db(name-map, packages)
+  val all-definitions = to-tuple $ seq-cat({_}, values(definitions(database)))
 
-  val database = stz/defs-db/create-defs-db(name-map, [core-package])
-  val all-definitions = seq-cat({_}, values(definitions(database)))
-  val function = 
-    for def in all-definitions find! : 
-      name(def) == `with-output-stream
-  
-  #EXPECT(to-string(annotation?(function)) == "<?TV0>(_0:OutputStream, _1:() -> ?TV0) -> TV0")
+  defn test-annotation (name:Symbol, annotation:String) : 
+    val function = find!({/name(_) == name}, all-definitions)
+    #EXPECT(to-string(annotation?(function)) == annotation)
+
+  test-annotation(`with-output-stream, "<?TV0>(_0:OutputStream, _1:() -> ?TV0) -> TV0")
+  test-annotation(`fork-on-seq, "<?TV0, ?TV1>(_0:Seqable<?TV0>, _1:Seqable<(Seq<TV0>) -> ?TV1>) -> Tuple<TV1>")
+  test-annotation(`to-chunks, "<?T>(s:Seqable<?T>, chunk-sz:Int) -> Seq<Tuple<T>>")
+  test-annotation(`memoize*, "<T, ?S>(f:(T, (T, ?) -> S) -> ?S) -> (T) -> S")
+  test-annotation(`maps-equal?, "<?T>(lhs:?T, rhs:?T, map-functions:Tuple<(T) -> Equalable>) -> True|False")
+  test-annotation(`apply, "<?T0, ?T1, ?T2, ?R>(f:(T0, T1, T2) -> ?R, args:[?T0, ?T1, ?T2]) -> R")
+  test-annotation(`tuple-zip, "<?A0, ?R0, ?A1, ?R1>(f:[(A0) -> ?R0, (A1) -> ?R1], args:[?A0, ?A1]) -> [R0, R1]")


### PR DESCRIPTION
- Added printers for PackageDefinition and its children.

- Added more comprehensive tests for tricky function signatures.

- Corrected stringify? applied to DOf, DTuple, and IOf AST nodes.