### PR TITLE
Update core/Process library for Windows.

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -9107,8 +9107,8 @@ val PIPE-ID-GENERATOR = Random()
 
 public lostanza deftype Process :
   var pid: long
-  var pipeid: int
   var handle: ptr<?>
+  var pipeid: int
   var input: ptr<?>
   var output: ptr<?>
   var error: ptr<?>
@@ -9180,7 +9180,7 @@ defn SystemCallException (msg:String) :
                                 error:ref<StreamSpecifier>,
                                 working-dir:ref<String|False>) -> ref<Process> :
     ensure-valid-stream-specifiers(input, output, error)
-    val proc = new Process{0, -1, null, null, null, null, false, false, false}
+    val proc = new Process{0, null, -1, null, null, null, false, false, false}
 
     ; Create a command line from the given filename and args (discarding the first argument).
     ; This is necessary because Windows' process API expects a command line (not a list of arguments).
@@ -9217,7 +9217,7 @@ defn SystemCallException (msg:String) :
     ensure-valid-stream-specifiers(input, output, error)
     val args = to-tuple(args0)
     val pipe-id = next-int(PIPE-ID-GENERATOR).value
-    val proc = new Process{0, pipe-id, null, null, null, null, false, false, false}
+    val proc = new Process{0, null, pipe-id, null, null, null, false, false, false}
     val input_v = value(input).value
     val output_v = value(output).value
     val error_v = value(error).value

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -82,7 +82,7 @@ protected extern stz_memory_resize: (ptr<?>, long, long) -> int
   protected extern launch_process: (ptr<byte>, ptr<ptr<byte>>, int, int, int, int, ptr<byte>, ptr<?>) -> int
   protected extern delete_process_pipes: (ptr<?>, ptr<?>, ptr<?>, int) -> int
   protected extern initialize_launcher_process: () -> int
-protected extern retrieve_process_state: (long, ptr<?>, int) -> int
+protected extern retrieve_process_state: (ptr<?>, ptr<?>, int) -> int
 
 
 ;Math libraries
@@ -9108,6 +9108,7 @@ val PIPE-ID-GENERATOR = Random()
 public lostanza deftype Process :
   var pid: long
   var pipeid: int
+  var handle: ptr<?>
   var input: ptr<?>
   var output: ptr<?>
   var error: ptr<?>
@@ -9179,7 +9180,7 @@ defn SystemCallException (msg:String) :
                                 error:ref<StreamSpecifier>,
                                 working-dir:ref<String|False>) -> ref<Process> :
     ensure-valid-stream-specifiers(input, output, error)
-    val proc = new Process{0, -1, null, null, null, false, false, false}
+    val proc = new Process{0, -1, null, null, null, null, false, false, false}
 
     ; Create a command line from the given filename and args (discarding the first argument).
     ; This is necessary because Windows' process API expects a command line (not a list of arguments).
@@ -9216,7 +9217,7 @@ defn SystemCallException (msg:String) :
     ensure-valid-stream-specifiers(input, output, error)
     val args = to-tuple(args0)
     val pipe-id = next-int(PIPE-ID-GENERATOR).value
-    val proc = new Process{0, pipe-id, null, null, null, false, false, false}
+    val proc = new Process{0, pipe-id, null, null, null, null, false, false, false}
     val input_v = value(input).value
     val output_v = value(output).value
     val error_v = value(error).value
@@ -9287,8 +9288,10 @@ lostanza deftype StateStruct :
   var code: int
 lostanza defn retrieve-state (p:ref<Process>, wait-for-termination?:ref<True|False>) -> ref<ProcessState> :
   val s = new StateStruct{0, 0}
-  call-c clib/retrieve_process_state(p.pid, addr!([s]), (wait-for-termination? == true) as int)
-
+  val ec = call-c clib/retrieve_process_state(addr!([p]), addr!([s]), (wait-for-termination? == true) as int)
+  if ec != 0 :
+    throw(SystemCallException(platform-error-msg()))
+  
   ;State Codes
   val RUNNING = 0
   val DONE = 1

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -1008,7 +1008,9 @@ stz_int launch_process(stz_byte* file, stz_byte** argvs, stz_int input,
   return 0;
 }
 
-void retrieve_process_state (stz_long pid, ProcessState* s, stz_int wait_for_termination){
+int retrieve_process_state (Process* process, ProcessState* s, stz_int wait_for_termination){
+  stz_int pid = process->pid;
+  
   //Check whether launcher has been initialized
   if(launcher_pid < 0){
     fprintf(stderr, "Launcher not initialized.\n");
@@ -1023,6 +1025,7 @@ void retrieve_process_state (stz_long pid, ProcessState* s, stz_int wait_for_ter
 
   //Read back process state
   read_process_state(launcher_out, s);
+  return 0;
 }
 #else
 #include "process-win32.c"

--- a/runtime/process-win32.c
+++ b/runtime/process-win32.c
@@ -44,26 +44,50 @@ static FILE* file_from_handle(HANDLE handle, FileType type) {
   return file;
 }
 
-int retrieve_process_state (Process* process, ProcessState* s, stz_int wait_for_termination) {
-  ProcessState state;
-  DWORD exit_code;
-
+// Polls a running `process` returning the `ProcessState`, optionally blocking until it has terminated.
+int retrieve_process_state (const Process* process, ProcessState* s, stz_int wait_for_termination) {
+  ProcessState state;  // the returned state. 
+  DWORD exit_code;     // the exit code of the process
+  HANDLE handle;       // the handle to the process 
+  
+  // By default, assume the process is still running.
   state = (ProcessState){PROCESS_RUNNING, 0};
 
-  if (wait_for_termination == 1) {
-    if (WaitForSingleObject(process->handle, INFINITE) == WAIT_FAILED) {
+  // First, attempt to open a handle to the process to query its state by process ID.
+  // This is required to check a currently running process, as we do not have the permissions
+  // associated with the original handle created by launch_process (??? TODO: verify the cause)
+  handle = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_INFORMATION, FALSE, process->pid);
+
+  // If the wait_for_termination argument has been passed, and the handle is valid, we 
+  // call WaitForSingleObject until the process exits. Requires a valid handle.
+  if (wait_for_termination && handle) {
+    // if WaitForSingleObject fails, return an error. The caller must retrieve the
+    // platform error message and raise an exception.
+    if (WaitForSingleObject(handle, INFINITE) == WAIT_FAILED) {
       return -1;
     }
   }
 
-  if (!GetExitCodeProcess(process->handle, &exit_code)) {
+  // If the returned handle is invalid, it means that the process has failed and we need
+  // to query the return code using original handle to the process.
+  if (!handle) {
+    handle = process->handle;
+  }
+
+  // Attempt to get the exit code from the handle. If this fails, return an error. The
+  // caller must retrieve the platform error message and return an exception.
+  if (!GetExitCodeProcess(handle, &exit_code)) {
     return -1;
   }
 
+  // If the exit code is not STILL_ACTIVE, the process is done.
   if (exit_code != STILL_ACTIVE) {
     state = (ProcessState){PROCESS_DONE, (stz_int)exit_code};
+    // Make sure we close the handle after we're done with it.
+    CloseHandle(handle);
   }
   
+  // Write the returned state and return success.
   *s = state;
   return 0;
 }
@@ -236,7 +260,7 @@ stz_int launch_process(stz_byte* command_line,
       /* lpProcessAttributes  */ NULL,
       /* lpThreadAttributes   */ NULL,
       /* bInheritHandles      */ TRUE,
-      /* dwCreationFlags      */ 0,
+      /* dwCreationFlags      */ CREATE_NO_WINDOW,
       /* lpEnvironment        */ NULL,
       /* lpCurrentDirectory   */ (LPSTR)working_dir,
       /* lpStartupInfo        */ &start_info,

--- a/runtime/process.h
+++ b/runtime/process.h
@@ -7,8 +7,8 @@
 
 typedef struct {
   stz_long pid;
-  stz_int pipeid;
   void* handle;
+  stz_int pipeid;
   FILE* in;
   FILE* out;
   FILE* err;

--- a/runtime/process.h
+++ b/runtime/process.h
@@ -8,6 +8,7 @@
 typedef struct {
   stz_long pid;
   stz_int pipeid;
+  void* handle;
   FILE* in;
   FILE* out;
   FILE* err;

--- a/tests/stanza.proj
+++ b/tests/stanza.proj
@@ -21,6 +21,7 @@ package stz/test-infer defined-in "test-infer.stanza"
 package stz/test-constant-fold-gen defined-in "test-constant-fold-gen.stanza"
 package stz/test-constants defined-in "test-constants.stanza"
 package stz/test-inline-targ defined-in "test-inline-targ.stanza"
+package stz/test-process-api defined-in "test-process-api.stanza"
 
 ;These tests can only be run in compiled mode because
 ;they require bindings to be compiled into the VM.

--- a/tests/test-process-api.stanza
+++ b/tests/test-process-api.stanza
@@ -1,0 +1,32 @@
+#use-added-syntax(tests)
+defpackage stz/test-process-api : 
+  import core
+
+; Poll a process until it exits, failing the test if the process
+; takes longer than the timeout argumnet
+defn check-exits-within-timeout (timeout:Long, process:Process) : 
+  val timer = MillisecondTimer("time-process")
+  start(timer)
+  let loop () : 
+    #ASSERT(time(timer) < timeout)
+    sleep-us(10L)
+    loop() when state(process) is ProcessRunning
+
+; This test verifies polling a short-running process works as expected
+deftest test-short-process :
+  val process = Process("sleep", ["sleep", "0.01"])
+  check-exits-within-timeout(100L, process)
+
+; This test verifies polling a longer-running process works as expected
+deftest test-long-process :
+  val process = Process("sleep", ["sleep", "1s"])
+  check-exits-within-timeout(2000L, process)
+
+; This test verifies that polling a process after it has exited works
+; as expected.
+deftest test-short-process-exit-before-poll : 
+  val process = Process("sleep", ["sleep", "0.01"])
+  ; Sleep for five seconds, then poll the process. 
+  for n in 0 to 10 do : 
+    sleep-us(500L * 1000L)
+  check-exits-within-timeout(20L, process)


### PR DESCRIPTION
- Change `clib/retrieve_process_state` to accept a pointer to a `Process` instead of using `pid`.
- Remove usage of `OpenProcess`, as lookup by pid fails if called long after the process terminates.
- Return an error if `retrieve_process_state` fails on
Windows (either in `WaitForSingleObject` or `GetExitCodeProcess`)
- Add a `handle` field to `Process` to hold the process handle created by `CreateProcess`.