### PR TITLE
Fix a bug in relocate-liveness-trackers

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -2593,15 +2593,13 @@ lostanza defn relocate-liveness-trackers (vms:ptr<VMState>) -> ref<False> :
   val compaction-start = heap.compaction-start
   ;p is a pointer to the list being scanned.
   var p:ptr<ptr<LivenessTracker>> = addr(heap.liveness-trackers)
-  ;GC preserves the allocation order, so:
-  ;  1) Tracker value is always below the tracker.
-  ;  2) Later trackers in the list are below earlier trackers.
-  while [p] > compaction-start :
+  while [p] != null :
     ;Retrieve the next ptr<LivenessTracker> in the list.
     val tracker = [p]
-    val tracker-obj = (tracker as ptr<long>) - sizeof(long)
-    ;Relocate the pointer to the tracker
-    [p] = tracker + relocation-offset(tracker-obj)
+    if tracker > compaction-start :
+      val tracker-obj = (tracker as ptr<long>) - sizeof(long)
+      ;Relocate the pointer to the tracker
+      [p] = tracker + relocation-offset(tracker-obj)
     ;Relocate the tracker value
     relocate-reference(addr(tracker.value), vms)
     ;Go to the next element in the list.
@@ -3806,7 +3804,7 @@ public lostanza defn set-max-heap-size (sz:ref<Long>) -> ref<False> :
 
   ;Update the new limit on the maximum size of the heap.
   heap.size-limit = desired-size
-  
+
   ;No meaningful return value
   return false
 
@@ -9263,7 +9261,7 @@ defn SystemCallException (msg:String) :
 
 #else:
   val PIPE-ID-GENERATOR = Random()
-  
+
   public lostanza defn Process (filename:ref<String>,
                                 args0:ref<Seqable<String>>,
                                 input:ref<StreamSpecifier>,
@@ -9347,7 +9345,7 @@ lostanza defn retrieve-state (p:ref<Process>, wait-for-termination?:ref<True|Fal
   val ec = call-c clib/retrieve_process_state(addr!([p]), addr!([s]), (wait-for-termination? == true) as int)
   if ec != 0 :
     throw(SystemCallException(platform-error-msg()))
-  
+
   ;State Codes
   val RUNNING = 0
   val DONE = 1


### PR DESCRIPTION
Relocation of liveness trackers was written in assumption that GC preserves allocation order. So the trackers in the list are visited in the decreasing address order and the tracked value are always below the tracker. That was true until copying evacuation from the nursery was introduced. The evacuation can change the allocation order and so can break the assumptions. It may lead to subtle bugs with references in the tracker list and references from trackers to tracked values  are not updated.