### PR TITLE
Add additional escapes in string literals

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -9723,16 +9723,23 @@ public defn writeln-all (xs:Seqable) :
 ;                    ================
 
 defn general-escape (o:OutputStream, c:Char) :
-   defn escape (c:Char) :
-      print(o, '\\')
-      print(o, c)
-   switch {c == _} :
-      '\t' : escape('t')
-      '\b' : escape('b')
-      '\r' : escape('r')
-      '\n' : escape('n')
-      '\\' : escape('\\')
-      else : print(o, c)
+  defn escape (c:Char) :
+    print(o, '\\')
+    print(o, c)
+  switch {c == _} :
+    to-char(0x07Y) : escape('a')
+    to-char(0x1bY) : escape('e')
+    to-char(0x0CY) : escape('f')
+    to-char(0x0BY) : escape('v')
+    to-char(0x00Y) : escape('0')
+    '\"' : escape('\"')
+    '\'' : escape('\'')
+    '\t' : escape('t')
+    '\b' : escape('b')
+    '\r' : escape('r')
+    '\n' : escape('n')
+    '\\' : escape('\\')
+    else : print(o, c)
 
 defn escape-for-string (o:OutputStream, c:Char) :
    if c == '\"' :

--- a/core/reader.stanza
+++ b/core/reader.stanza
@@ -323,6 +323,11 @@ defn remove-cr (s:String) -> String :
 
 ;Create escape character table
 val ESCAPE-TABLE = Array<Char|False>(256, false)
+ESCAPE-TABLE[to-int('a')] = to-char(0x07Y)
+ESCAPE-TABLE[to-int('e')] = to-char(0x1bY)
+ESCAPE-TABLE[to-int('f')] = to-char(0x0CY)
+ESCAPE-TABLE[to-int('v')] = to-char(0x0BY)
+ESCAPE-TABLE[to-int('0')] = to-char(0x00Y)
 ESCAPE-TABLE[to-int('t')] = '\t'
 ESCAPE-TABLE[to-int('b')] = '\b'
 ESCAPE-TABLE[to-int('r')] = '\r'


### PR DESCRIPTION
This PR adds support for ANSI escape chars and the null character in string literals, and updates the writer implementation for strings. 

Example : 

```stanza
defpackage program : 
  import core
  import collections

val string = "\a\b\e\f\n\r\t\v\"\'\0\\"
println("%@" % [string])
```

Running this code prints :

```
stanza> reload
'\a' '\b' '\e' '\f' '\n' '\r' '\t' '\v' '\"' '\'' '\0' '\\'
```