### PR TITLE
Index doc strings in definitions database/pkg files

### DIFF
--- a/compiler/stz-bindings-to-vm.stanza
+++ b/compiler/stz-bindings-to-vm.stanza
@@ -90,13 +90,13 @@ defn bindings-packageio (bindings:Bindings) -> [PackageIO, BindingIds] :
   val reg-array-id = ValId(`stz/vm, `register-array)
   val ids = BindingIds(GlobalId(0), CodeId(1))
   if empty?(extern-defns(bindings)) :
-    val packageio = PackageIO(gensym(`bindings), [], [], [])
+    val packageio = PackageIO(gensym(`bindings), [], [], [], false)
     [packageio, ids]
   else :
     val imports = [
       Import(0, ValRec(reg-array-id, DPtrT(DLong()), true, true), false)
       Import(1, FnRec(call-extern-id, DInt(), true, false), false)]
-    val packageio = PackageIO(gensym(`bindings), [`stz/vm], imports, [])
+    val packageio = PackageIO(gensym(`bindings), [`stz/vm], imports, [], false)
     [packageio, ids]
 
 defstruct BindingIds :

--- a/compiler/stz-defs-db-ir.stanza
+++ b/compiler/stz-defs-db-ir.stanza
@@ -28,6 +28,7 @@ public defstruct Definition <: Equalable :
   kind:SrcDefinitionKind 
   visibility:Visibility
   annotation?:False|DefinitionAnnotation  
+  documentation?:False|String
 
 doc: "Represents the kind of item associated with a definition."
 public defenum SrcDefinitionKind : 
@@ -113,6 +114,7 @@ defmethod print (o:OutputStream, def:Definition) :
   lnprint(oo, "kind: %_" % [kind(def)])
   lnprint(oo, "visibility: %_" % [visibility(def)])
   lnprint(oo, "annotation?: %_" % [annotation?(def)])
+  lnprint(oo, "documentation?: %_" % [documentation?(def)])
 
 defmethod print (o:OutputStream, a:FnArgAnnotation) : 
   match(name?(a), type?(a)) : 

--- a/compiler/stz-defs-db-serializer.stanza
+++ b/compiler/stz-defs-db-serializer.stanza
@@ -20,7 +20,8 @@ public defserializer (out:OutputStream, in:InputStream) :
 
   defunion definition2 (Definition) :
     Definition : (name:symbol, file-info:fileinfo, kind:src-def-kind,
-                   visibility:visibility, annotation?:opt<DefinitionAnnotation>(annotation))
+                  visibility:visibility, annotation?:opt<DefinitionAnnotation>(annotation)
+                  documentation?:opt<String>(string))
 
   defunion package-import (PackageImport) : 
     PackageImport : (name:symbol, prefixes:tuple(package-import-prefix))

--- a/compiler/stz-defs-db.stanza
+++ b/compiler/stz-defs-db.stanza
@@ -132,13 +132,14 @@ defn build-package-defs (pkg:Pkg, stamp:PackageStamp, nm:NameMap) -> PackageDefi
   ;Convert each of the exports into the database Definition objects.
   val definitions = to-tuple $     
     for e in exports-with-infos seq :
-      Definition(name, info, kind, visibility, annotation?) where :
+      Definition(name, info, kind, visibility, annotation?, documentation?) where :
         val name = name(id(rec(e)))
         val info = info(e) as FileInfo
         val visibility = visibility(e)
         val kind = kindof(rec(e))
         val annotation? = annotate?(e, nm)
-
+        val documentation? = documentation?(e)
+  
   ;Bundle the results in the PackageDefinitions datastructure.
   PackageDefinitions(name(pkg),
                      stamp,
@@ -162,12 +163,13 @@ protected-when(TESTING) defn build-package-defs (ipackage:IPackage, stamp:Packag
   val indexed-exps = index-expressions(exps(ipackage), nm)
   val definitions = to-tuple $
     for indexed in indexed-exps seq :  
-      Definition(name, info, kind, visibility, annotation) where : 
+      Definition(name, info, kind, visibility, annotation?, documentation?) where : 
         val name = name(indexed)
         val info = info(indexed)
         val kind = kind(indexed)
         val visibility = visibility(indexed)
-        val annotation = annotation?(indexed)
+        val annotation? = annotation?(indexed)
+        val documentation? = documentation?(indexed)
 
   ;Bundle results in PackageDefinitions structure.
   PackageDefinitions(name(ipackage),
@@ -193,9 +195,14 @@ protected-when(TESTING) defn build-package-defs (ipackage:IPackage, stamp:Packag
 ; - If an `Indexable` does not have an `info`, it is skipped
 ; - If an `Indexable`'s name cannot be found, it is skipped 
 protected-when(TESTING) defn index-expressions (exps:Seqable<IExp>, nm:NameMap) -> Seq<Indexed> :
-  generate<Indexed> : 
+  generate<Indexed> :
+    var documentation?:False|String = false
     defn loop (e:IExp, current-visibility:Visibility) :
       match(e) : 
+        ; Case 0: We encounter a doc string. Store and attribute it with
+        ;         the next expression.
+        (d:IDoc) :
+          documentation? = value(string(d) as ILiteral) as String
         ; Case 1: We encounter a visibility node. Walk its
         ;         child with the new visibility.
         (v:IVisibility) : 
@@ -205,15 +212,19 @@ protected-when(TESTING) defn index-expressions (exps:Seqable<IExp>, nm:NameMap) 
         (b:IBegin) : 
           do(loop{_, current-visibility}, /exps(b))
         ; Case 3: We find an Indexable. Attempt to index it.
-        (i:Indexable&IExp) : 
+        (i:Indexable&IExp) :
+          ; Extract metadata from the IExp. 
           val name = name?(i, nm)
           val info = info(i as IExp)
           val kind = kindof(i)
           val annotation? = annotate?(i, nm)
+          val doc? = documentation?
+          documentation? = false ; consume the documentation buffer
+
           ; Case 4a.: Successfully found info and name, yield
           ; Case 4b.: (implicit) If name or info is not found, skip.
           match(info:FileInfo, name:Symbol) : 
-            yield(Indexed(kind, current-visibility, name, info, annotation?))
+            yield(Indexed(kind, current-visibility, name, info, annotation?, doc?))
         ; Case 5: We encounter an IExp we can't index. Skip.
         (e:?) :
           false ; do nothing
@@ -336,6 +347,7 @@ protected defstruct Indexed <: Equalable :
   name:Symbol
   info:FileInfo
   annotation?:False|DefinitionAnnotation
+  documentation?:False|String
 with : 
   printer => true
 

--- a/compiler/stz-dl-ir.stanza
+++ b/compiler/stz-dl-ir.stanza
@@ -13,6 +13,7 @@ public defstruct PackageIO :
   imported-packages: Tuple<Symbol> with: (updater => sub-imported-packages)
   imports: Tuple<Import> with: (updater => sub-imports)
   exports: Tuple<Export> with: (updater => sub-exports)
+  documentation?:False|String with: (updater => sub-documentation)
 
 public defstruct PackageExports :
   package: Symbol
@@ -28,6 +29,7 @@ public defstruct Export :
   visibility: Visibility
   rec: Rec
   info: FileInfo|False
+  documentation?:False|String
 
 public defstruct Import :
   n: Int with: (updater => sub-n)
@@ -572,7 +574,7 @@ defsyntax dl-ir :
                          imported-packages = (?ips:#symbol ...)
                          ?imports:#import ...
                          ?exports:#export ...) :
-    PackageIO(name, to-tuple(ips), to-tuple(imports), to-tuple(exports))
+    PackageIO(name, to-tuple(ips), to-tuple(imports), to-tuple(exports), false) ; TODO add doc string reader macro
 
   defproduction dtype : DType
   defrule dtype = (byte) : DByte()
@@ -666,7 +668,7 @@ defsyntax dl-ir :
   fail-if import = (import) : DLE(closest-info(), "Invalid import statement.")
 
   public defproduction export : Export
-  defrule export = (export ?n:#int ?v:#vis ?r:#rec) : Export(n,v,r,closest-info())
+  defrule export = (export ?n:#int ?v:#vis ?r:#rec) : Export(n,v,r,closest-info(), false) ;TODO documentation? in reader macro
   fail-if export = (export) : DLE(closest-info(), "Invalid export statement.")
 
   defproduction transient? : True|False

--- a/compiler/stz-el-ir.stanza
+++ b/compiler/stz-el-ir.stanza
@@ -991,7 +991,7 @@ defsyntax el-ir :
   defrule epackage = (package ?name:#symbol : (?ss:#tstmt ... #E)) :
     val ins = to-tuple(filter-by<Import>(ss))
     val exs = to-tuple(filter-by<Export>(ss))
-    val io = PackageIO(name, [], ins, exs)                
+    val io = PackageIO(name, [], ins, exs, false)
     val es = to-tuple(filter-by<ETExp>(ss))
     EPackage(io, to-tuple(es))
 

--- a/compiler/stz-el.stanza
+++ b/compiler/stz-el.stanza
@@ -203,7 +203,7 @@ defn collapse (epackages:Tuple<EPackage>) :
         for ex in exports(packageio(e)) seq :
           val n* = global-rec-ids[id(rec(ex))]
           sub-n(ex, n*)
-    PackageIO(`prog, [], [], exports*)
+    PackageIO(`prog, [], [], exports*, false) ; TODO: should there be a doc string passed here?
 
   ;Rename one specific package
   defn renamed-exps (epackage:EPackage) :

--- a/compiler/stz-il-ir.stanza
+++ b/compiler/stz-il-ir.stanza
@@ -11,6 +11,7 @@ public defmulti info (e:IExp) -> False|FileInfo
 
 public defstruct IPackage :
   name: Symbol
+  documentation?: IDoc|False
   imports: Tuple<IImport> with: (updater => sub-imports)
   exps: List<IExp> with: (updater => sub-exps)
   info: FileInfo|False

--- a/compiler/stz-input.stanza
+++ b/compiler/stz-input.stanza
@@ -307,7 +307,9 @@ defn split-packages (e:IExp, default-imports:Tuple<IImport>) :
     if not empty?(eseq) :
       val pkg? =
         match(peek(eseq)) :
-          (d:IDoc) : loop(d)
+          (d:IDoc) :
+            next(eseq) 
+            loop(d)
           (e:IDefPackage) :
             next(eseq)
             val exps = to-list(take-while({_ is-not IDefPackage}, eseq))

--- a/compiler/stz-input.stanza
+++ b/compiler/stz-input.stanza
@@ -303,20 +303,25 @@ defn split-packages (e:IExp, default-imports:Tuple<IImport>) :
   
   ;Group packages
   val packages = Vector<IPackage>()
-  while not empty?(eseq) :
-    val pkg = match(peek(eseq)) :
-      (e:IDefPackage) :
-        next(eseq)
-        val exps = to-list(take-while({_ is-not IDefPackage}, eseq))
-        val imports = to-tuple $ seq(to-iimport, imports(e) as List<IImportExp>)
-        IPackage(name!(e), imports, exps, info(e))
-      (e:IExp) :
-        val exps = to-list(take-while({_ is-not IDefPackage}, eseq))
-        val info = info(head(exps))
-        val name = gensym(`default)
-        IPackage(name, default-imports, exps, info)
-    add(packages, pkg)
-
+  let loop (doc?:IDoc|False = false) : 
+    if not empty?(eseq) :
+      val pkg? =
+        match(peek(eseq)) :
+          (d:IDoc) : loop(d)
+          (e:IDefPackage) :
+            next(eseq)
+            val exps = to-list(take-while({_ is-not IDefPackage}, eseq))
+            val imports = to-tuple $ seq(to-iimport, imports(e) as List<IImportExp>)
+            IPackage(name!(e), doc?, imports, exps, info(e))
+          (e:IExp) :
+            val exps = to-list(take-while({_ is-not IDefPackage}, eseq))
+            val info = info(head(exps))
+            val name = gensym(`default)
+            IPackage(name, doc?, default-imports, exps, info)
+      match(pkg?:IPackage) :
+        add(packages, pkg?)
+      loop(false)
+      
   ;Return packages
   to-tuple(packages)
 

--- a/compiler/stz-pkg.stanza
+++ b/compiler/stz-pkg.stanza
@@ -367,10 +367,10 @@ defserializer (out:FileOutputStream, in:FileInputStream) :
   ;==== PackageIO ====
   ;===================
   defunion packageio (PackageIO) :
-    PackageIO: (package:symbol, imported-packages:tuple(symbol), imports:tuple(dimport), exports:tuple(dexport))
+    PackageIO: (package:symbol, imported-packages:tuple(symbol), imports:tuple(dimport), exports:tuple(dexport), documentation?:opt<String>(string))
 
   defunion dexport (Export) :
-    Export: (n:int, visibility:visibility, rec:drec, info:opt<FileInfo>(info))
+    Export: (n:int, visibility:visibility, rec:drec, info:opt<FileInfo>(info), documentation?:opt<String>(string))
 
   defunion dimport (Import) :
     Import: (n:int, rec:drec, transient?:bool)

--- a/compiler/stz-repl.stanza
+++ b/compiler/stz-repl.stanza
@@ -635,11 +635,13 @@ defn REPLEnv () :
           do(add-import, imports(import-list-table[p]))
         add-import(IImport(p, [], false, true))
       (p:False) : false
+
     ;If we have custom imports from user interaction, then import those.
     do(add-import, values(repl-imports))
 
     ;Create IPackage
     IPackage(gensym(`repl),
+             false,
              to-tuple(values(exp-imports)),
              List(exp),
              info(exp))

--- a/compiler/stz-resolver.stanza
+++ b/compiler/stz-resolver.stanza
@@ -135,7 +135,7 @@ public defn resolve-il (packages:Tuple<IPackage|PackageExports>, env:Env) -> Res
         add(import-lists*, ImportList(name(p), imports(p)))
         add(ipackages*, p*)
     resolve-ipackages() when not empty?(ps) or not empty?(ds)
-      
+
   ;Resolve type dependencies from pkgs
   check-exported-types(symtables, ipackages*, package-exports(symtables), error-accum)
 

--- a/compiler/stz-tl-ir.stanza
+++ b/compiler/stz-tl-ir.stanza
@@ -211,7 +211,8 @@ public defast :
          lbl: Symbol
       TLInit :
          comm: LSComm
-
+      TDoc :
+         string: TExp
 
    ;     HiStanza Expressions
    ;     --------------------

--- a/compiler/stz-tl-to-dl.stanza
+++ b/compiler/stz-tl-to-dl.stanza
@@ -100,17 +100,26 @@ defn compute-exports (p:TPackage, namemap:NameMap) :
 
   ;Discover all exported entries
   val exports = Vector<Export>()
-  defn export (n:Int, r:Rec) :
+  defn export* (n:Int, r:Rec, d?:False|String) :
     val [vis, info] =
       if key?(namemap,n) :
         val e = namemap[n]
         [visibility(e), info(e)]
       else :
         [Private, false]
-    add(exports, Export(n, vis, r, info))
-    
+    add(exports, Export(n, vis, r, info, d?))
+  
+  ; Track the most recently observed doc string and associate
+  ; it with the next export. Intermediate doc strings are dropped.
+  var last-doc? : False|String = false
+  defn export (n:Int, r:Rec) :
+    export*(n, r, last-doc?)
+    last-doc? = false
+
   for c in comms(p) do :
     match(c) :
+      (c:TDoc) :
+        last-doc? = value(string(c) as TLiteral) as String
       (c:TDefType) :
         val id = get-typeid(n(c))
         val ntargs = length(args(c))

--- a/compiler/stz-tl-to-el.stanza
+++ b/compiler/stz-tl-to-el.stanza
@@ -34,6 +34,8 @@ defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap) :
 
   for c in comms(p) do :
     match(c) :
+      (c:TDoc) :
+        false ; do nothing
       (c:TDefType) :
         val parent = to-etype?(parent(c))
         val children = to-tuple(seq(n,children(c)))
@@ -1189,7 +1191,8 @@ defn analyze-imports (p:EPackage, export-table:ExportTable, transient-package?:T
   val io* = PackageIO(name(p),
                       new-imported-packages,
                       to-tuple(new-imports),
-                      exports(io))
+                      exports(io),
+                      documentation?(io))
   ensure-consistency!(io*)
   io*
 

--- a/compiler/stz-type.stanza
+++ b/compiler/stz-type.stanza
@@ -131,7 +131,11 @@ defn to-tprog (ipackages:Tuple<IPackage>, nm:NameMap, environment:Tuple<Export>)
     let-var accum = Vector<TComm>() :
       do(#comm, exps(ipackage))
       val imported-packages = map(package, imports(ipackage))
-      val io = PackageIO(name(ipackage), imported-packages, [], [])
+      val doc? = 
+        match(documentation?(ipackage)) : 
+          (doc:IDoc) : value(string(doc) as ILiteral) as String
+          (f:False)  : false
+      val io = PackageIO(name(ipackage), imported-packages, [], [], doc?)
       TPackage(io, to-list(accum))
 
   defn #comm (e:IExp) -> False :
@@ -215,7 +219,7 @@ defn to-tprog (ipackages:Tuple<IPackage>, nm:NameMap, environment:Tuple<Export>)
         ILSDo|ILSPrim|ILSCallC) :
         add-comm(TLInit(#lscomm(e), info(e)))
       (e:IDoc) :
-        false
+        add-comm(TDoc(#exp(string(e)), info(e)))
       (e) :
         fatal("Unsupported form: %~" % [e])
 
@@ -1177,6 +1181,8 @@ defn infer-types (prog:TProg) :
   ;======== Productions ========
   defn bcomm<?T> (c:?T&TComm) -> T :
     {_ as T&TComm} $ match(c) :
+      (c:TDoc) :
+        c
       (c:TDefType) :
         c
       (c:TLDefType) :
@@ -1968,6 +1974,8 @@ defn infer-types (prog:TProg) :
   defn update-env (prog:TProg) :
     for c in prog do :
       match(c) :
+        (c:TDoc) :
+          false
         (c:TDefType) :
           false
         (c:TLDefType) :

--- a/compiler/stz-vm-ir.stanza
+++ b/compiler/stz-vm-ir.stanza
@@ -1027,7 +1027,7 @@ defsyntax vmcode :
                          ?stmts:#tstmt ...) :
     val ins = to-tuple(filter-by<Import>(stmts))
     val exs = to-tuple(filter-by<Export>(stmts))
-    val io = PackageIO(name, [], ins, exs)
+    val io = PackageIO(name, [], ins, exs, false)
     val gs = to-tuple(filter-by<VMGlobal>(stmts))
     val ds = to-tuple(filter-by<VMData>(stmts))
     val cts = to-tuple(filter-by<VMConst>(stmts))

--- a/compiler/stz-vm.stanza
+++ b/compiler/stz-vm.stanza
@@ -840,7 +840,7 @@ public defn load (vm:VirtualMachine, vmps:Collection<VMPackage>, keep-existing-g
 
 public defn unload (vm:VirtualMachine, ps:Collection<Symbol>) :
   val vmps = to-tuple $ for p in ps seq :
-    val io = PackageIO(p, [], [], [])
+    val io = PackageIO(p, [], [], [], false)
     VMPackage(io, false, [], [], [], [], [], [], [], [], VMDebugInfoTable([]))
   load(vm, vmps, false)
 

--- a/tests/indexing-data/test-package.stanza
+++ b/tests/indexing-data/test-package.stanza
@@ -48,3 +48,6 @@ defn tuple-zip<?A0, ?R0, ?A1, ?R1> (f:[A0 -> ?R0, A1 -> ?R1], args:[?A0, ?A1]) -
   val [f0, f1] = f
   val [a0, a1] = args
   [f0(a0), f1(a1)]
+
+doc: "A public struct."
+public defstruct PublicStruct

--- a/tests/test-definitions-database.stanza
+++ b/tests/test-definitions-database.stanza
@@ -43,12 +43,12 @@ deftest test-indexing-of-iexps :
   defn lookup? (name:Symbol) : 
     find({stz/defs-db/name(_) == name}, indexed)
   
-  #EXPECT(lookup?(`public-fn)     == stz/defs-db/Indexed(SrcDefFunction, Public,    `public-fn,     test-info(5, 12),  DefnAnnotation([], [], `Int)))
-  #EXPECT(lookup?(`protected-fn)  == stz/defs-db/Indexed(SrcDefFunction, Protected, `protected-fn,  test-info(6, 15),  DefnAnnotation([], [], `Int)))
-  #EXPECT(lookup?(`private-fn)    == stz/defs-db/Indexed(SrcDefFunction, Private,   `private-fn,    test-info(7, 5),   DefnAnnotation([], [], `Int)))
-  #EXPECT(lookup?(`PublicType)    == stz/defs-db/Indexed(SrcDefType,     Public,    `PublicType,    test-info(9, 15),  false))
-  #EXPECT(lookup?(`ProtectedType) == stz/defs-db/Indexed(SrcDefType,     Protected, `ProtectedType, test-info(10, 18), false))
-  #EXPECT(lookup?(`PrivateType)   == stz/defs-db/Indexed(SrcDefType,     Private,   `PrivateType,   test-info(11, 8),  false))
+  #EXPECT(lookup?(`public-fn)     == stz/defs-db/Indexed(SrcDefFunction, Public,    `public-fn,     test-info(5, 12),  DefnAnnotation([], [], `Int), false))
+  #EXPECT(lookup?(`protected-fn)  == stz/defs-db/Indexed(SrcDefFunction, Protected, `protected-fn,  test-info(6, 15),  DefnAnnotation([], [], `Int), false))
+  #EXPECT(lookup?(`private-fn)    == stz/defs-db/Indexed(SrcDefFunction, Private,   `private-fn,    test-info(7, 5),   DefnAnnotation([], [], `Int), false))
+  #EXPECT(lookup?(`PublicType)    == stz/defs-db/Indexed(SrcDefType,     Public,    `PublicType,    test-info(9, 15),  false, false))
+  #EXPECT(lookup?(`ProtectedType) == stz/defs-db/Indexed(SrcDefType,     Protected, `ProtectedType, test-info(10, 18), false, false))
+  #EXPECT(lookup?(`PrivateType)   == stz/defs-db/Indexed(SrcDefType,     Private,   `PrivateType,   test-info(11, 8),  false, false))
 
 ; Here, we test that the indexing algorithm correctly associates definitions with their source package.
 deftest test-indexing-to-definitions : 
@@ -162,3 +162,23 @@ deftest(long) test-annotated-pkg-defs :
   test-annotation(`maps-equal?, "<?T>(lhs:?T, rhs:?T, map-functions:Tuple<(T) -> Equalable>) -> True|False")
   test-annotation(`apply, "<?T0, ?T1, ?T2, ?R>(f:(T0, T1, T2) -> ?R, args:[?T0, ?T1, ?T2]) -> R")
   test-annotation(`tuple-zip, "<?A0, ?R0, ?A1, ?R1>(f:[(A0) -> ?R0, (A1) -> ?R1], args:[?A0, ?A1]) -> [R0, R1]")
+
+deftest test-doc-strings : 
+  val input = DefsDbInput(proj-files, platform, flags, optimize?, merge-db?) where : 
+    val proj-files = ["tests/indexing-data/stanza.proj"]
+    val platform   = `linux
+    val flags      = []
+    val optimize?  = false
+    val merge-db?  = false
+  
+  val deps     = stz/defs-db/analyze-input(input)
+  val database = stz/defs-db/gen-defs-db(deps)  
+  val all-defs = to-tuple(seq-cat(definitions, packages(database)))
+
+  defn has-doc-string? (name:Symbol, documentation?:False|String) -> True|False : 
+    for def in all-defs any? :
+      /name(def) == name and 
+      /documentation?(def) == documentation?
+
+  #EXPECT(has-doc-string?(`PublicStruct, "A public struct."))
+  #EXPECT(has-doc-string?(`PublicStruct, false))


### PR DESCRIPTION
- Added logic to extract IDoc from IL-IR in generation of definitions database from source code
- Added logic to TL and DL IRs to preserve doc strings when compiled into fpkg/pkg files.