### PR TITLE
Add sensible error message for duplicate imports

### DIFF
--- a/compiler/il-ir.stanza
+++ b/compiler/il-ir.stanza
@@ -26,12 +26,16 @@ public defstruct IImport :
   import-private?: True|False with: (default => false, updater => sub-import-private?)
 with:
   printer => true
+  equalable => true
+  hashable => true
 
 public defstruct IPrefix :
   names: False|Tuple<Symbol>
   prefix: String
 with:
   printer => true
+  equalable => true
+  hashable => true
 
 #with-added-syntax(stz-ast-lang) :
    public defast :

--- a/compiler/input.stanza
+++ b/compiler/input.stanza
@@ -402,7 +402,9 @@ defn to-iimport (e:IImportExp) -> IImport :
    public defcheck check (e:IExp) :
       ;======== Stanza Language ========
       pe("package level form") :
-         IDefPackage: {name:v imports:(imp ...)}
+         IDefPackage:
+            {name:v imports:(imp ...)}
+            custom{ensure-unique-imports(e)}
          ILoadPackage: ()
          IBegin: {exps:(pe ...)}
          + te
@@ -781,6 +783,13 @@ defn ensure-branch-arity (e:IMatch) :
    for b in bs do :
       if length(args(b)) != n :
          stz/check-lang-engine/error!(info(b), "The number of branch arguments does not match number of arguments given to match.")
+
+defn ensure-unique-imports (ipackage: IDefPackage) :
+  val import-set = HashSet<IImport>()
+  for i in imports(ipackage) do :
+    if not add(import-set, i) :
+      stz/check-lang-engine/error!(info(e), "defpackage %_ imports package %_ several times." % [
+                     name(ipackage), package(i)])
 
 defn ensure-doc-string (e:IExp) :
    match(e) :


### PR DESCRIPTION
# Change

Issue with duplicate imports:
```
defpackage hello-world :
  import core
  import json
  import json

println $ to-json-string("Hello world")
```

```
jstanza run hello-world.stanza     
hello-world.stanza:6.10: Ambiguous call to overloaded function to-json-string with arguments of type
(String). Possibilities are:
  to-json-string: JSON -> String at jitpcb/src/lib-json/lib-json.stanza:167.12
  to-json-string: JSON -> String at jitpcb/src/lib-json/lib-json.stanza:167.12
```
This only breaks if we call 1 function from the duplicated import, the proposed solution will make an error even if no function is called from the duplicated import.

# I could not run the change

How do recompile? I get:
```
lbstanza$ ../jitx-client/stanza/stanza stz/driver -o my-stanza
/usr/bin/ld: cannot find -lasmjit
collect2: error: ld returned 1 exit status
```