### PR TITLE
Update tests/conantest02/Makefile to work with released 0.17.42

### DIFF
--- a/tests/conantest02/Makefile
+++ b/tests/conantest02/Makefile
@@ -1,6 +1,6 @@
 
 # Stanza version to download in the form 0_12_34 matching what's in the zip filename
-STANZA_VERSION := 0_17_40
+STANZA_VERSION := 0_17_42
 
 # detect platform
 SYS := $(shell gcc -dumpmachine)
@@ -36,6 +36,10 @@ VERBOSE := -verbose
 all: asmjit-app
 
 
+# create build dir
+$(BUILD_DIR):
+	mkdir build
+
 # download and unzip stanza
 $(STANZA_DIR):
 	@echo "Downloading $(STANZA_ZIP)"
@@ -52,8 +56,8 @@ $(STANZA_DIR):
 
 
 # link final executable
-$(BUILD_DIR)/asmjit-app: stanza.proj ###_when_using_release_stanza >>> ### | .stanza
-	###_when_using_release_stanza >>> ### export STANZA_CONFIG="$$PWD"
+$(BUILD_DIR)/asmjit-app: stanza.proj | .stanza $(STANZA_DIR) $(BUILD_DIR)
+	export STANZA_CONFIG="$$PWD"
 	$(STANZA) compile asmjit-app -o $(BUILD_DIR)/asmjit-app $(VERBOSE)
 
 # convenience target


### PR DESCRIPTION
Small tweak to Makefile.  Just running `make` in the `tests/conantest02` will build the conan asmjit sample test in isolation with released version `0.17.42`.