### PR TITLE
Change conan default to build=missing

### DIFF
--- a/compiler/conan-package-manager.stanza
+++ b/compiler/conan-package-manager.stanza
@@ -45,13 +45,13 @@ public defn ConanPackageManager () -> ForeignPackageManager :
                   One $ "conan")
         ;These extra arguments are appended to the end of
         ;the call to 'conan install'.
-        ;The default '--build never' prevents Conan from
-        ;building the packages and opts to only download them.
+        ;The default '--build missing' instructs Conan to build packages
+        ;from source if no suitable binary package is available.
         TableEntry(`conan-install-extra-args
                    MULTIPLE-FLAGS
                    true
                    One $ List(
-                     ["--build" "never"]))
+                     ["--build" "missing"]))
         ;This is the default directory where all of the Conan
         ;files will be generated. By default it will be in 'build'.
         TableEntry(`conan-build-dir


### PR DESCRIPTION
If a required conan binary package is not available on the server, tell conan to build it from source.