### PR TITLE
Change conan build directory default to include WORKDIR

### DIFF
--- a/compiler/conan-package-manager.stanza
+++ b/compiler/conan-package-manager.stanza
@@ -53,11 +53,11 @@ public defn ConanPackageManager () -> ForeignPackageManager :
                    One $ List(
                      ["--build" "never"]))
         ;This is the default directory where all of the Conan
-        ;files will be generated. By default it will be in 'build'.
+        ;files will be generated. By default it will be in '{WORKDIR}/build'.
         TableEntry(`conan-build-dir
                    SINGLE-PATH
                    true
-                   One $ "build")
+                   One $ "{WORKDIR}/build")
         ;This is the default directory where the .conan cache
         ;directory will be created. By default it will be in the
         ;project root directory.


### PR DESCRIPTION
Change the default conan build directory from `build` to `{WORKDIR}/build`

Will stanza correctly replace the WORKDIR variable when used in this way?
