### PR TITLE
Fix implementation of dynamic-wind, let-var.

### DIFF
--- a/compiler/compiler-linking.stanza
+++ b/compiler/compiler-linking.stanza
@@ -517,7 +517,7 @@ defn execute-final-build-command (settings:BuildSettings,
               ccfiles(deps),
               flat-ccflags(deps),
               exefile)
-    catch (e) :
+    catch (e:Exception) :
       issue-error(env, ErrorLinkingAsmfile(filename(asmfile), exefile, e))
       false
 

--- a/compiler/core-macros.stanza
+++ b/compiler/core-macros.stanza
@@ -1672,12 +1672,16 @@ defsyntax core :
    ;                     =======
    val let-var-template = CoreExp $ `(
      let :
-       val ~oldv = ~x
+       var ~oldv:?
        val ~v = ~e
        core/dynamic-wind(
-         fn () : ~x = ~v
-         fn () : ~body
-         fn () : ~x = ~oldv))
+         fn () :
+           ~oldv = ~x
+           ~x = ~v
+         fn () :
+           ~body
+         fn () :
+           ~x = ~oldv))
    defrule exp4 = (let-var ?x:#id! = ?e:#exp! #:! ?body:#exp!) :
      fill(let-var-template, [
        `x => x

--- a/compiler/core-macros.stanza
+++ b/compiler/core-macros.stanza
@@ -1733,7 +1733,7 @@ defsyntax core :
       nested $ to-tuple $
          for (c in clauses, i in 0 to false) seq :
             [`x => binder(c)
-             `type => value?(type(c), `core/Throwable)
+             `type => value?(type(c), `core/Exception)
              `first? => choice(i == 0)
              `body => body(c)]
       

--- a/compiler/core-macros.stanza
+++ b/compiler/core-macros.stanza
@@ -1733,8 +1733,7 @@ defsyntax core :
       nested $ to-tuple $
          for (c in clauses, i in 0 to false) seq :
             [`x => binder(c)
-             `type? => choice(not empty?(type(c)))
-             `type => value?(type(c))
+             `type => value?(type(c), `core/Throwable)
              `first? => choice(i == 0)
              `body => body(c)]
       
@@ -1751,14 +1750,10 @@ defsyntax core :
                      fn () :
                         body
                      fn (e) :
-                        catch-all?{
-                           true
-                        }{
-                           e is clauses{first?{}{|} type}
-                        }
+                        e is clauses{first?{}{|} type}
                      fn (e) :
                         match(e) :
-                           clauses{(x type?{: type}{}) : body})
+                           clauses{(x:type) : body})
                }
             fn () :
                fbody))
@@ -1768,7 +1763,6 @@ defsyntax core :
             `e => gensym(`e)
             `catch => choice(empty?(clauses))
             `clauses => compile-catch-clauses(clauses)
-            `catch-all? => choice(any?(empty?{type(_)}, clauses))
             `fbody => fbody]))
 
    defrule exp4 = (try #:! ?body:#exp! ?clauses0:#catch-clause ?clausesn:#catch-clause ...) :
@@ -1777,20 +1771,15 @@ defsyntax core :
             fn () :
                body
             fn (e) :
-               catch-all?{
-                  true
-               }{
-                  e is clauses{first?{}{|} type}
-               }
+               e is clauses{first?{}{|} type}
             fn (e) :
                match(e) :
-                  clauses{(x type?{: type}{}) : body}))
+                  clauses{(x:type) : body}))
       val clauses = cons(clauses0, clausesn)
       parse-syntax[core / #exp](
          fill-template(template, [
             `body => body
             `e => gensym(`e)
-            `catch-all? => choice(any?(empty?{type(_)}, clauses))
             `clauses => compile-catch-clauses(clauses)]))
    fail-if exp4 = (try #:! #exp!) :
       CSE(closest-info(), "Try expression without any catch or finally clauses.")

--- a/compiler/fastio-serializer-lang-parser.stanza
+++ b/compiler/fastio-serializer-lang-parser.stanza
@@ -276,7 +276,7 @@ defn process-includes (s:DefSerializer) -> DefSerializer :
         try :
           process $ parse-serializer-exps(
                       filename(info(e)), filename(e))
-        catch (err) :
+        catch (err:Exception) :
           throw(FastIOIncludeError(info(e), filename(e), err))
       else :
         add(accum, e)

--- a/compiler/macro-master.stanza
+++ b/compiler/macro-master.stanza
@@ -37,7 +37,7 @@ public defn load-macro-plugin (filename:String,
   val lib =
     try :
       dynamic-library-open(ensure-slash(filename))
-    catch (e) :
+    catch (e:Exception) :
       throw(ErrorLoadingMacroPlugin(filename, e))
 
   ;Test that it's a valid macro plugin

--- a/compiler/params.stanza
+++ b/compiler/params.stanza
@@ -18,7 +18,7 @@ public defn compiler-flags () :
   to-tuple(COMPILE-FLAGS)
 
 ;========= Stanza Configuration ========
-public val STANZA-VERSION = [0 17 54]
+public val STANZA-VERSION = [0 17 55]
 public var STANZA-INSTALL-DIR:String = ""
 public var OUTPUT-PLATFORM:Symbol = `platform
 public var STANZA-PKG-DIRS:List<String> = List()

--- a/compiler/test-framework.stanza
+++ b/compiler/test-framework.stanza
@@ -259,7 +259,7 @@ protected defn run-test (t:DefTest) :
       ;Execute body with exceptions logged.
       defn with-logged-exceptions (body:() -> ?) :
         label break :
-          defn log-exception (e:Exception) -> Void :
+          defn log-exception (e:Throwable) -> Void :
             println(out, "[FAIL]")
             println(out2, "Uncaught Exception: %_" % [e])
             print-stack-trace(out2)

--- a/core/collections.stanza
+++ b/core/collections.stanza
@@ -775,7 +775,10 @@ public defn HashTable<K,V> (cap0:Int
 ;==================================
 ;==== Convenience Constructors ====
 ;==================================
-defn no-such-key (k) : fatal("Key %_ does not exist in table." % [k])
+
+;Trivial default function which just throws a RuntimeError.
+defn no-such-key (k) -> Void :
+  throw(MissingTableKey(k))
 
 public defn HashTable<K,V> (initial-cap:Int, hash: K -> Int, equal?: (K,K) -> True|False) :
   HashTable<K,V>(initial-cap, hash, equal?, no-such-key, false)
@@ -1734,3 +1737,13 @@ public defn to-intset (xs:Seqable<Int>) -> IntSet :
 defmethod print (o:OutputStream, s:IntSet) :
   print(o, "IntSet(%,)" % [seq(written,s)])
  
+;============================================================
+;==================== Errors ================================
+;============================================================
+
+;Occurs when we try to set/get a missing key in a table.
+public defstruct MissingTableKey <: RuntimeError :
+  key
+
+defmethod print (o:OutputStream, e:MissingTableKey) :
+  print(o, "Key %_ does not exist in table." % [key(e)])

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3559,11 +3559,11 @@ defn pop-frame (s:DyCtxtState,
 ;------------ Main Wind-in / Wind-out Algorithms ------------
 ;------------------------------------------------------------
 
-;Execute all wind-out dynamic frames, pushing them into the
-;winder. Starts from c and traverses its parent chain until
-;target-id (inclusive) is processed.
+;Execute all wind-out dynamic frames, pushing them into the winder (if
+;given). Starts from c and traverses its parent chain until target-id
+;(inclusive) is processed.
 defn wind-out (c:RawCoroutine,
-               winder:DyCtxtWinder,
+               winder:DyCtxtWinder|False,
                target-id:Int,
                call-out?:True|False,
                call-finally?:True|False) -> False :
@@ -3574,7 +3574,8 @@ defn wind-out (c:RawCoroutine,
         loop(parent(c) as RawCoroutine)
     else :
       val f = pop-frame(s, call-out?, call-finally?)
-      push(winder, id(c), f)
+      match(winder:DyCtxtWinder) :
+        push(winder, id(c), f)
       loop(c)
 
 ;Execute the stored wind-in frames in the winder, pushing them
@@ -3690,9 +3691,6 @@ protected lostanza deftype RawCoroutine <: Coroutine & Unique :
   var crsp: long
   dy-ctxt-state: ref<DyCtxtState>
 
-lostanza defn dy-ctxt-state (co:ref<RawCoroutine>) -> ref<DyCtxtState> :
-  return co.dy-ctxt-state
-
 lostanza deftype CoroutineParams :
   parent-stack: ref<Stack>
   coroutine: ref<RawCoroutine>
@@ -3728,6 +3726,8 @@ lostanza defn status (c:ref<RawCoroutine>) -> ref<Int> :
   return c.status
 lostanza defn id (c:ref<RawCoroutine>) -> ref<Int> :
   return new Int{c.id as int}
+lostanza defn dy-ctxt-state (co:ref<RawCoroutine>) -> ref<DyCtxtState> :
+  return co.dy-ctxt-state
 
 lostanza defmethod active? (c:ref<RawCoroutine>) -> ref<True|False> :
   if c.status == COROUTINE-ACTIVE : return true
@@ -3772,22 +3772,6 @@ lostanza defmethod resume (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Return the result yielded by the coroutine.
   return result
 
-;;Return true if any of the given winders has a final callback.
-;defn has-final-callback? (winders:List<Winder>) -> True|False :
-;  for w in winders any? :
-;    final(w) is-not False
-
-;If the coroutine's saved winders contains a final callback and a
-;finalizer has not been attached to run them when the coroutine
-;is collected, then add it now.
-;lostanza defn add-winders-finalizer-if-necessary? (c:ref<RawCoroutine>) -> ref<False> :
-;  val saved-winders = c.saved-winders
-;  if saved-winders.attached-finalizer? == false and
-;     has-final-callback?(saved-winders.winders) == true :
-;    add-finalizer(new WinderFinalizer{saved-winders}, c)
-;    saved-winders.attached-finalizer? = true
-;  return false
-
 lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Ensure coroutine is active
   if c.status == COROUTINE-CLOSED :
@@ -3798,10 +3782,10 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
     return fatal("Cannot suspend coroutine. Coroutine is already suspended.")
 
   ;Ensure coroutine was launched within same c context
-  ensure-target-in-same-c-ctxt!(c)
+  ensure-no-cross-ffi-call-boundary!(c)
 
-  ;Retrieve the pack of frames since parent was last exited,
-  ;and wind out.
+  ;Wind out from current-coroutine until we reach c.
+  ;Save wind-out frames into the winder.
   val winder = DyCtxtWinder()
   wind-out(current-coroutine, winder, id(c), true, false)
 
@@ -3814,7 +3798,7 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Return to resume
   val result = call-prim yield(current-coroutine.stack, x)
 
-  ;Clear winders so now the coroutine is attached again.
+  ;Clear winders now that the coroutine is attached again.
   clear-winders(c)
 
   ;Wind in the dynamic context state.
@@ -3848,20 +3832,11 @@ lostanza defmethod break (c:ref<RawCoroutine>, x:ref<?>) -> ref<Void> :
     return fatal("Cannot break from coroutine. Coroutine is already suspended.")
 
   ;Ensure coroutine was launched within same c context
-  ensure-target-in-same-c-ctxt!(c)
+  ensure-no-cross-ffi-call-boundary!(c)
 
-  ;Retrieve the pack of frames since parent was last exited,
-  ;and wind out.
-  val winder = DyCtxtWinder()
-  wind-out(current-coroutine, winder, id(c), true, true)
-
-;  call-c clib/printf("[%ld] Wind out\n", stack-id)
-;
-;  ;Set target winder environment and wind out
-;  val winders = pop-winders(total-winders(c.parent))
-;  wind-out(winders, true, true)
-;
-;  call-c clib/printf("[%ld] Wind outs finished\n", stack-id)
+  ;Wind out from the current coroutine. No need
+  ;to store the frames since we won't wind-in again.
+  wind-out(current-coroutine, false, id(c), true, true)
 
   ;Adjust state
   detach-coroutine(c, COROUTINE-CLOSED)
@@ -3869,17 +3844,21 @@ lostanza defmethod break (c:ref<RawCoroutine>, x:ref<?>) -> ref<Void> :
   ;Begin execution
   return call-prim yield(current-coroutine.stack, x)
 
+;Return true if suspending from this coroutine will cross the FFI call boundary.
 lostanza defmethod suspension-crosses-ffi-call-boundary? (c:ref<RawCoroutine>) -> ref<True|False> :
   val crsp = call-prim crsp() as long
   if crsp == c.crsp : return false
   else : return true
 
-lostanza defn ensure-target-in-same-c-ctxt! (c:ref<RawCoroutine>) -> int :
-  val crsp = call-prim crsp() as long
-  if c.crsp != crsp :
-    fatal!("Cannot suspend coroutine. Coroutine was launched from a different C context. All 'extern defn' callbacks must return properly.")
+;Issue an error if suspending from this coroutine results in crossing the FFI call boundary.
+lostanza defn ensure-no-cross-ffi-call-boundary! (c:ref<RawCoroutine>) -> int :
+  if suspension-crosses-ffi-call-boundary?(c) == true :
+    fatal!("Cannot suspend coroutine. Coroutine was launched from a different C context. \
+            All 'extern defn' callbacks must return properly.")
   return 0
 
+;The given coroutine is finished. Close it and
+;free all it stacks.
 lostanza defn free-coroutine (c:ref<RawCoroutine>) -> int :
   labels :
     begin :
@@ -3893,6 +3872,9 @@ lostanza defn free-coroutine (c:ref<RawCoroutine>) -> int :
         (p:ref<RawCoroutine>) : goto loop(p)
         (p:ref<False>) : return 0
 
+;Fix up the .parent, .status, and .crsp links from
+;attaching the given coroutine to 'current-coroutine'.
+;The current coroutine will be set to the last parent in the chain.
 lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :  
   labels :
     begin :

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3615,12 +3615,6 @@ defn dynamic-wind<?T> (body:() -> ?T,
   pop-frame(s, true, true)
   result
 
-;Execute the given body within the given dynamic context.
-public defn dynamic-wind<?T> (in:False|(() -> ?),
-                              body:() -> ?T,
-                              out:False|(() -> ?)) -> T :
-  dynamic-wind(body, DyCtxtFrame(in, out))
-
 ;Wind in and then wind out of all entries in the given winder.
 ;Used to force finally blocks to run.
 defn wind-in-out (winder:DyCtxtWinder) -> False :
@@ -3629,6 +3623,16 @@ defn wind-in-out (winder:DyCtxtWinder) -> False :
     if i < num :
       dynamic-wind(loop{i + 1}, value(pop(winder)))
     false
+
+;Execute the given body within the given dynamic context.
+public defn dynamic-wind<?T> (in:False|(() -> ?),
+                              body:() -> ?T,
+                              out:False|(() -> ?)) -> T :
+  dynamic-wind(body, DyCtxtFrame(in, out))
+
+;Run the given body with the equipped finally block.
+public defn with-finally<?T> (body: () -> ?T, finally: () -> ?) -> T :
+  dynamic-wind(body, DyCtxtFinallyFrame(finally))
 
 ;============================================================
 ;====================== Coroutines ==========================
@@ -6082,8 +6086,19 @@ public lostanza defn exit (code:ref<Int>) -> ref<Void> :
 ;===================== Exceptions ===========================
 ;============================================================
 
-;Represents all exceptions.
-public deftype Exception <: Unique
+;Represents all throwable objects.
+;Meant to act as a common ancestor of Exception and RuntimeException.
+public deftype Throwable <: Unique
+
+;Represents all standard exceptions.
+public deftype Exception <: Throwable
+
+;Represents errors that are uncommonly caught.
+;'try/catch' blocks default to Exception if no
+;type is provided for the catch argument, and hence
+;does not include RuntimeError. The user should expect
+;RuntimeError to mostly not be caught except for deliberately.
+public deftype RuntimeError <: Throwable
 
 ;Simple constructor for a generic exception.
 public defn Exception (msg) -> Exception :
@@ -6092,21 +6107,19 @@ public defn Exception (msg) -> Exception :
       print(o, msg)
 
 ;Holds the currently-equipped exception handler.
-var CURRENT-EXCEPTION-HANDLER : Exception -> Void =
-  fn (e:Exception) :
+var CURRENT-EXCEPTION-HANDLER : Throwable -> Void =
+  fn (e:Throwable) :
     fatal(e)
 
-public var CURRENT-HANDLER-NAME:String = "Default"
-
 ;Throw the given exception to the currently-set handler.
-public defn throw (e:Exception) :
+public defn throw (e:Throwable) :
   CURRENT-EXCEPTION-HANDLER(e)
 
 ;Run the given body with the equipped exception interceptor.
 public defn with-exception-interceptor<?T> (body: () -> ?T,
-                                            intercept: Exception -> Void) -> T :
+                                            intercept: Throwable -> Void) -> T :
   val handler = CURRENT-EXCEPTION-HANDLER
-  defn interceptor (e:Exception) :
+  defn interceptor (e:Throwable) :
     CURRENT-EXCEPTION-HANDLER = handler
     intercept(e)
   let-var CURRENT-EXCEPTION-HANDLER = interceptor :
@@ -6114,16 +6127,16 @@ public defn with-exception-interceptor<?T> (body: () -> ?T,
 
 ;Run the given body with the equipped catchers.
 public defn with-exception-handler<?T> (body: () -> ?T,
-                                        catch?: Exception -> True|False,
-                                        catcher: Exception -> ?T) -> T :
+                                        catch?: Throwable -> True|False,
+                                        catcher: Throwable -> ?T) -> T :
   ;Execute the body within a label so that stack can be unwound.
   val r = label<ExceptionResult|NormalResult> break :
     ;Holds the outer handler during the dynamic extent of this 'try' block.
     ;Will be set during wind-in.
-    var outer-handler:Exception -> Void
+    var outer-handler:Throwable -> Void
 
     ;Implementation of throw within the body.
-    defn throw-within-body (e:Exception) :
+    defn throw-within-body (e:Throwable) :
       ;First check whether the catcher is supposed to handle this
       ;exception.
       if catch?(e) :
@@ -6152,26 +6165,10 @@ public defn with-exception-handler<?T> (body: () -> ?T,
 
 ;Represents the return value from a body when equipped
 ;with catchers.
-defstruct ExceptionResult : (exception: Exception)
+defstruct ExceptionResult : (exception: Throwable)
 defstruct NormalResult : (result)
 
-;Run the given body with the equipped finally block.
-public defn with-finally<?T> (body: () -> ?T, finally: () -> ?) -> T :
-  val s = dy-ctxt-state(current-coroutine)
-  val frame = DyCtxtFinallyFrame(finally)
-  push-frame(s, frame)
-  val result = body()
-  pop-frame(s, true, true)
-  result
 
-
-;  push-winder(Winder(false, false, finally))
-;  inc-winders(current-coroutine, 1)
-;  val result = body()
-;  pop-winder()
-;  inc-winders(current-coroutine, -1)
-;  finally()
-;  result
 
 ;============================================================
 ;============== Input/Output Exceptions =====================

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3408,48 +3408,37 @@ defmethod length (x:List) :
 ;=================== Dynamic Context ========================
 ;============================================================
 
-;Represents a new dynamic context frame.
+;------------------------------------------------------------
+;----------- Representation of one Dynamic Frame ------------
+;------------------------------------------------------------
+;A dynamic frame consists of an entry thunk and an exit thunk.
+;A boolean flag indicates whether the exit thunk is a
+;'finally' block or not. Finally blocks are treated specially.
+
 defstruct DyCtxtFrame :
   finally?:True|False
   in: False|(() -> ?)
   out: False|(() -> ?)
 
-;Represents the state of the dynamic context stack in
-;a single coroutine.
-defstruct DyCtxtState <: Finalizer :
-  frames:List<DyCtxtFrame> with:
-    setter => set-frames
-    init => List()
-  saved:DyCtxtWinder|False with:
-    setter => set-saved
-    init => false
-  registered?:True|False with:
-    setter => set-registered?
-    init => false
+;Create a new non-finally dynamic context frame.
+defn DyCtxtFrame (in:False|(() -> ?),
+                  out:False|(() -> ?)) -> DyCtxtFrame :
+  DyCtxtFrame(false, in, out)                
 
-;Wind in and out the saved frames.
-defmethod run (s:DyCtxtState) -> False :
-  if saved(s) is-not False :
-    val winder = saved(s) as DyCtxtWinder
-    set-saved(s, false)
-    wind-in-out(winder)
+;Create a new finally dynamic context frame.
+defn DyCtxtFinallyFrame (out:False|(() -> ?)) -> DyCtxtFrame :
+  DyCtxtFrame(true, false, out)
 
-;Save the winders in the coroutine, so that if the coroutine
-;is closed, we can run the finally blocks.
-defn save-winders (co:RawCoroutine, w:DyCtxtWinder) -> False :
-  if contains-finally?(w) :
-    val s = dy-ctxt-state(co)
-    set-saved(s, w)
-    if not registered?(s) :
-      set-registered?(s,true)
-      add-finalizer(s, co)
+;------------------------------------------------------------
+;------------- State of a Winding Algorithm -----------------
+;------------------------------------------------------------
+;A DyCtxtWinder captures the in-progress state of performing
+;a wind-in, or wind-out operation.
+;As frames are pushed/popped into a coroutine, they are saved
+;onto the winder.
 
-;Clear the winders in the coroutine because it's attached again.
-defn clear-winders (co:RawCoroutine) -> False :
-  set-saved(dy-ctxt-state(co), false)
-
-;Represents a runner that is winding-in/winding-out a set of
-;dynamic context frames.
+;- entries: Each entry, CO => F, means that the frame
+;F was popped from the state of coroutine CO during wind-out.
 defstruct DyCtxtWinder :
   entries:List<KeyValue<Int,DyCtxtFrame>> with:
     setter => set-entries
@@ -3461,8 +3450,8 @@ defn contains-finally? (w:DyCtxtWinder) -> True|False :
   for e in entries(w) any? :
     finally?(value(e))
 
-;Returns the number of entries that need to be processed
-;to obtain all finally blocks.
+;Returns the minimum number of entries to pop
+;from winder until 'contains-finally?' returns false.
 defn num-finally-blocks (w:DyCtxtWinder) -> Int :
   var last-index:Int = -1
   for (e in entries(w), i in 0 to false) do :
@@ -3488,20 +3477,59 @@ defn pop (w:DyCtxtWinder) -> KeyValue<Int,DyCtxtFrame> :
 defn peek (w:DyCtxtWinder) -> KeyValue<Int,DyCtxtFrame> :
   head(entries(w))
 
-;Create a new non-finally dynamic context frame.
-defn DyCtxtFrame (in:False|(() -> ?),
-                  out:False|(() -> ?)) -> DyCtxtFrame :
-  DyCtxtFrame(false, in, out)                
+;------------------------------------------------------------
+;---------------- State of Dynamic Context ------------------
+;------------------------------------------------------------
+;Each coroutine stores its own stack of dynamic frames.
 
-;Create a new finally dynamic context frame.
-defn DyCtxtFinallyFrame (out:False|(() -> ?)) -> DyCtxtFrame :
-  DyCtxtFrame(true, false, out)
+;- frames: The frames that have finished winding-in.
+;  Most recent wind-in is at front.
+;- saved: If the coroutine is suspended and in OPEN status,
+;  then this contains a DyCtxtWinder that contains finally
+;  blocks that need to execute when the coroutine is closed.
+;- registered?: The DyCtxtState doubles as a finalizer which
+;  executes its saved finally blocks. To prevent it from
+;  being registered repeatedly, this field holds true if it
+;  has already been registered as a finalizer.
+defstruct DyCtxtState <: Finalizer :
+  frames:List<DyCtxtFrame> with:
+    setter => set-frames
+    init => List()
+  saved:DyCtxtWinder|False with:
+    setter => set-saved
+    init => false
+  registered?:True|False with:
+    setter => set-registered?
+    init => false
+
+;Execute the saved finally blocks.
+defmethod run (s:DyCtxtState) -> False :
+  if saved(s) is-not False :
+    val winder = saved(s) as DyCtxtWinder
+    set-saved(s, false)
+    wind-in-out(winder)
+
+;The coroutine co has just been suspended. Save the finally
+;blocks, and register the finalizer.
+defn save-winders (co:RawCoroutine, w:DyCtxtWinder) -> False :
+  if contains-finally?(w) :
+    val s = dy-ctxt-state(co)
+    set-saved(s, w)
+    if not registered?(s) :
+      set-registered?(s,true)
+      add-finalizer(s, co)
+
+;The coroutine co has just been resumed, so we don't need
+;its saved winders anymore.
+defn clear-winders (co:RawCoroutine) -> False :
+  set-saved(dy-ctxt-state(co), false)
 
 ;Returns true if the state has no more frames.
 defn empty? (s:DyCtxtState) -> True|False :
   empty?(frames(s))
 
 ;Execute and push a new frame onto the state.
+;The frame is pushed *after* it executes. 
 defn push-frame (s:DyCtxtState, f:DyCtxtFrame) -> False :
   match(in(f)) :
     (f:False) : false
@@ -3509,6 +3537,9 @@ defn push-frame (s:DyCtxtState, f:DyCtxtFrame) -> False :
   set-frames(s, cons(f, frames(s)))
 
 ;Pop a new frame from the state, and execute it.
+;The frame is *first* popped and then executed.
+;non-finally out-blocks are executed only if call-out? is true.
+;finally out-blocks are executed only if call-finally? is true.
 defn pop-frame (s:DyCtxtState,
                 call-out?:True|False,
                 call-finally?:True|False) -> DyCtxtFrame :
@@ -3524,7 +3555,13 @@ defn pop-frame (s:DyCtxtState,
         f-out() when call-out?
   f
 
-;Execute wind-out frames and save into winder.
+;------------------------------------------------------------
+;------------ Main Wind-in / Wind-out Algorithms ------------
+;------------------------------------------------------------
+
+;Execute all wind-out dynamic frames, pushing them into the
+;winder. Starts from c and traverses its parent chain until
+;target-id (inclusive) is processed.
 defn wind-out (c:RawCoroutine,
                winder:DyCtxtWinder,
                target-id:Int,
@@ -3540,7 +3577,8 @@ defn wind-out (c:RawCoroutine,
       push(winder, id(c), f)
       loop(c)
 
-;Execute wind-in frames in winder and push onto state.
+;Execute the stored wind-in frames in the winder, pushing them
+;back onto the coroutine state.
 defn wind-in (winder:DyCtxtWinder, c:RawCoroutine) -> False :
   if not empty?(winder) :
     defn* pop-next-frame (cos:List<RawCoroutine>) :
@@ -3556,6 +3594,15 @@ defn wind-in (winder:DyCtxtWinder, c:RawCoroutine) -> False :
         exec-frame(tail(cos), co-id, frame)
     val entry0 = peek(winder)
     pop-next-frame(reverse(collect-parents(c, key(entry0))))
+
+;Collect parents up to the given parent-id.
+defn collect-parents (c:RawCoroutine, parent-id:Int) -> List<RawCoroutine> :
+  if id(c) == parent-id : List(c)
+  else : cons(c, collect-parents(parent(c) as RawCoroutine, parent-id))
+
+;------------------------------------------------------------
+;--------------- Dynamic Wind Algorithm ---------------------
+;------------------------------------------------------------
 
 ;Execute the given body with the given frame pushed into
 ;the dynamic context of the current coroutine.
@@ -3581,11 +3628,6 @@ defn wind-in-out (winder:DyCtxtWinder) -> False :
     if i < num :
       dynamic-wind(loop{i + 1}, value(pop(winder)))
     false
-
-;Collect parents up to the given parent-id.
-defn collect-parents (c:RawCoroutine, parent-id:Int) -> List<RawCoroutine> :
-  if id(c) == parent-id : List(c)
-  else : cons(c, collect-parents(parent(c) as RawCoroutine, parent-id))
 
 ;============================================================
 ;====================== Coroutines ==========================

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3408,289 +3408,184 @@ defmethod length (x:List) :
 ;=================== Dynamic Context ========================
 ;============================================================
 
-;A counter for generating ids for dynamic context frames.
-var DYNAMIC-CONTEXT-COUNTER:Seq<Int>
-
-;Global stack of dynamic contexts.
-var DYNAMIC-CONTEXTS:Vector<DyCtxtFrame>
-
-;Initialize the global variables necessary for
-;tracking dynamic contexts.
-defn initialize-dynamic-contexts () :
-  DYNAMIC-CONTEXT-COUNTER = to-seq(0 to false)
-  DYNAMIC-CONTEXTS = Vector<DyCtxtFrame>()
-
 ;Represents a new dynamic context frame.
-lostanza deftype DyCtxtFrame :
-  id:int
-  finally?:int
-  in: ref<False|(() -> ?)>
-  out: ref<False|(() -> ?)>
+defstruct DyCtxtFrame :
+  finally?:True|False
+  in: False|(() -> ?)
+  out: False|(() -> ?)
 
-lostanza defn id (f:ref<DyCtxtFrame>) -> ref<Int> :
-  return new Int{f.id}
-lostanza defn finally? (f:ref<DyCtxtFrame>) -> ref<True|False> :
-  if f.finally? : return true
-  else : return false
-lostanza defn in (f:ref<DyCtxtFrame>) -> ref<False|(() -> ?)> :
-  return f.in
-lostanza defn out (f:ref<DyCtxtFrame>) -> ref<False|(() -> ?)> :
-  return f.out
+;Represents the state of the dynamic context stack in
+;a single coroutine.
+defstruct DyCtxtState <: Finalizer :
+  frames:List<DyCtxtFrame> with:
+    setter => set-frames
+    init => List()
+  saved:DyCtxtWinder|False with:
+    setter => set-saved
+    init => false
+  registered?:True|False with:
+    setter => set-registered?
+    init => false
 
-public defn print-dynamic-contexts () :
-  println("Dynamic Context:")
-  for f in in-reverse(DYNAMIC-CONTEXTS) do :
-    print("  ")
-    println(f)
+;Wind in and out the saved frames.
+defmethod run (s:DyCtxtState) -> False :
+  if saved(s) is-not False :
+    val winder = saved(s) as DyCtxtWinder
+    set-saved(s, false)
+    wind-in-out(winder)
 
-defmethod print (o:OutputStream, f:DyCtxtFrame) :
-  val in-str = " " when in(f) is False else "^"
-  val out-str = " " when out(f) is False else "v"
-  val f-str = "F" when finally?(f) else " "
-  print(o, "[%_ | %_ | %_ %_]" % [id(f), in-str, out-str, f-str])
+;Save the winders in the coroutine, so that if the coroutine
+;is closed, we can run the finally blocks.
+defn save-winders (co:RawCoroutine, w:DyCtxtWinder) -> False :
+  if contains-finally?(w) :
+    val s = dy-ctxt-state(co)
+    set-saved(s, w)
+    if not registered?(s) :
+      set-registered?(s,true)
+      add-finalizer(s, co)
+
+;Clear the winders in the coroutine because it's attached again.
+defn clear-winders (co:RawCoroutine) -> False :
+  set-saved(dy-ctxt-state(co), false)
+
+;Represents a runner that is winding-in/winding-out a set of
+;dynamic context frames.
+defstruct DyCtxtWinder :
+  entries:List<KeyValue<Int,DyCtxtFrame>> with:
+    setter => set-entries
+    init => List()
+
+;Returns true if any of the entries in the winder is a
+;finally block.
+defn contains-finally? (w:DyCtxtWinder) -> True|False :
+  for e in entries(w) any? :
+    finally?(value(e))
+
+;Returns the number of entries that need to be processed
+;to obtain all finally blocks.
+defn num-finally-blocks (w:DyCtxtWinder) -> Int :
+  var last-index:Int = -1
+  for (e in entries(w), i in 0 to false) do :
+    if finally?(value(e)) :
+      last-index = i
+  last-index + 1
+
+;Return true if the winder has no more entries.
+defn empty? (w:DyCtxtWinder) -> True|False :
+  empty?(entries(w))
+
+;Push a new entry to the winder.
+defn push (w:DyCtxtWinder, co-id:Int, frame:DyCtxtFrame) :
+  set-entries(w, cons(co-id => frame, entries(w)))
+
+;Pop an entry from the winder.
+defn pop (w:DyCtxtWinder) -> KeyValue<Int,DyCtxtFrame> :
+  val e = head(entries(w))
+  set-entries(w, tail(entries(w)))
+  e
+
+;Take a look at the top entry in the winder.
+defn peek (w:DyCtxtWinder) -> KeyValue<Int,DyCtxtFrame> :
+  head(entries(w))
 
 ;Create a new non-finally dynamic context frame.
-lostanza defn DyCtxtFrame (in:ref<False|(() -> ?)>,
-                           out:ref<False|(() -> ?)>) -> ref<DyCtxtFrame> :
-  return new DyCtxtFrame{
-           next(DYNAMIC-CONTEXT-COUNTER).value
-           0,
-           in,
-           out}
+defn DyCtxtFrame (in:False|(() -> ?),
+                  out:False|(() -> ?)) -> DyCtxtFrame :
+  DyCtxtFrame(false, in, out)                
 
 ;Create a new finally dynamic context frame.
-lostanza defn DyCtxtFinallyFrame (f:ref<(() -> ?)>) -> ref<DyCtxtFrame> :
-  return new DyCtxtFrame{
-           next(DYNAMIC-CONTEXT-COUNTER).value
-           1,
-           false,
-           f}
+defn DyCtxtFinallyFrame (out:False|(() -> ?)) -> DyCtxtFrame :
+  DyCtxtFrame(true, false, out)
 
-;Represents the state of the dynamic context stack.
-;- length: The number of active dynamic frames when this coroutine was
-;  resumed.
-;- top: The top-most frame when this coroutine was resumed.
-;- num-frames: The number of frames in the coroutine.
-lostanza deftype DyCtxtState :
-  var length:int
-  var top:int
-  var num-frames:int
+;Returns true if the state has no more frames.
+defn empty? (s:DyCtxtState) -> True|False :
+  empty?(frames(s))
 
-;Represents a pack of dynamic context frames.
-lostanza deftype DyCtxtPack :
-  length:long
-  var frames:ref<DyCtxtFrame> ...
+;Execute and push a new frame onto the state.
+defn push-frame (s:DyCtxtState, f:DyCtxtFrame) -> False :
+  match(in(f)) :
+    (f:False) : false
+    (f-in:() -> ?) : f-in()
+  set-frames(s, cons(f, frames(s)))
 
-lostanza defn contains-finally? (pack:ref<DyCtxtPack>) -> long :
-  val len = pack.length
-  for (var i:long = 0, i < len, i = i + 1) :
-    val f = pack.frames[i]
-    if f.finally? : return 1
-  return 0
+;Pop a new frame from the state, and execute it.
+defn pop-frame (s:DyCtxtState,
+                call-out?:True|False,
+                call-finally?:True|False) -> DyCtxtFrame :
+  val f = head(frames(s))
+  set-frames(s, tail(frames(s)))
+  match(out(f)) :
+    (f:False) :
+      false
+    (f-out:() -> ?) :
+      if finally?(f) :
+        f-out() when call-finally?
+      else :
+        f-out() when call-out?
+  f
 
-lostanza defn length (p:ref<DyCtxtPack>) -> ref<Int> : 
-  return new Int{p.length as int}
-
-lostanza defn get (p:ref<DyCtxtPack>, i:ref<Int>) -> ref<DyCtxtFrame> :
-  return p.frames[i.value]
-
-defmethod print (o:OutputStream, p:DyCtxtPack) :
-  val n = length(p)
-  if n == 0 :
-    print(o, "DyCtxtPack: ()")
-  else :
-    print(o, "DyCtxtPack:")
-    for i in reverse(0 to length(p)) do :
-      lnprint(o, "  %_" % [p[i]])
-
-;Retrieve the current state of the dynamic context stack.
-;Used for when a Coroutine is created.
-lostanza defn store-current-dynamic-context-state (s:ref<DyCtxtState>) -> ref<False> :
-  val len = length(DYNAMIC-CONTEXTS).value
-  s.length = len
-  if len > 0 : s.top = peek(DYNAMIC-CONTEXTS).id
-  else : s.top = 0
-  return false
-
-;Retrieve the top-n frames on the dynamic context stack, and return
-;the frames as a pack.
-lostanza defn dynamic-context-pack (state:ref<DyCtxtState>) -> ref<DyCtxtPack> :
-  ensure-consistent-state(state)
-  val num-frames = length(DYNAMIC-CONTEXTS).value
-  val pack-length = num-frames - state.length
-  if pack-length == 0 :
-    return EMPTY-DY-CTXT-PACK
-  else :
-    val start = state.length
-    val frame0 = get(DYNAMIC-CONTEXTS, new Int{start})
-    val pack = new DyCtxtPack{pack-length, frame0}
-    for (var i:long = 1, i < pack-length, i = i + 1) :
-      pack.frames[i] = frame0
-    for (var i:int = 1, i < pack-length, i = i + 1) :
-      pack.frames[i] = get(DYNAMIC-CONTEXTS, new Int{start + i})
-    return pack
-
-lostanza defn ensure-consistent-state (s:ref<DyCtxtState>) -> ref<False> :
-  ;Ensure the length is proper.
-  if s.length > length(DYNAMIC-CONTEXTS).value :
-    fatal(larger-state-than-expected(new Int{s.length}, length(DYNAMIC-CONTEXTS)))
-  ;Ensure the frame id is expected.
-  if s.length > 0 :
-    val f = get(DYNAMIC-CONTEXTS, new Int{s.length - 1})
-    if f.id != s.top :
-      fatal(wrong-dy-state(new Int{s.top}, new Int{f.id}))
-  return false
-
-defn larger-state-than-expected (expected:Int, actual:Int) :
-  "Expected length of dynamic context stack is %_, but actual \
-   length is %_." % [expected, actual]
-   
-defn wrong-dy-state (expected:Int, actual:Int) :
-  "Expected frame id is %_, but actual frame is %_." % [expected, actual]
-
-lostanza val EMPTY-DY-CTXT-PACK:ref<DyCtxtPack> = new DyCtxtPack{0}
-
-;Push a single dynamic context frame after we execute it.
-lostanza defn push-dy-ctxt-frame (f:ref<DyCtxtFrame>) -> ref<False> :
-  if f.in != false :
-    val f-in = f.in as ref<(() -> ?)>
-    [f-in]()
-  add(DYNAMIC-CONTEXTS, f)
-  return false
-
-;Pop a single dynamic context frame and then execute it.
-lostanza defn pop-dy-ctxt-frame (f:ref<DyCtxtFrame>,
-                                 call-out?:ref<True|False>,
-                                 call-finally?:ref<True|False>) -> ref<False> :
-  ;Check sanity frame.
-  if empty?(DYNAMIC-CONTEXTS) == true :
-    fatal(empty-dy-stack(new Int{f.id}))
-  if peek(DYNAMIC-CONTEXTS).id != f.id :
-    val top = peek(DYNAMIC-CONTEXTS)
-    fatal(wrong-dy-stack(new Int{f.id}, new Int{top.id}))
-
-  ;Pop the top frame.
-  pop(DYNAMIC-CONTEXTS)
-
-  ;Call the frame out if requested.
-  if f.out != false :
-    val f-out = f.out as ref<(() -> ?)>
-    if f.finally? :
-      if call-finally? == true : [f-out]()
+;Execute wind-out frames and save into winder.
+defn wind-out (c:RawCoroutine,
+               winder:DyCtxtWinder,
+               target-id:Int,
+               call-out?:True|False,
+               call-finally?:True|False) -> False :
+  let loop (c:RawCoroutine = c) :
+    val s = dy-ctxt-state(c)
+    if empty?(s) :
+      if id(c) != target-id :
+        loop(parent(c) as RawCoroutine)
     else :
-      if call-out? == true : [f-out]()
-  return false
+      val f = pop-frame(s, call-out?, call-finally?)
+      push(winder, id(c), f)
+      loop(c)
 
-;Wind out a frame pack.
-lostanza defn wind-out (pack:ref<DyCtxtPack>,
-                        call-out?:ref<True|False>
-                        call-finally?:ref<True|False>) -> ref<False> :
-  for (var i:long = pack.length - 1, i >= 0, i = i - 1) :
-    pop-dy-ctxt-frame(pack.frames[i], call-out?, call-finally?)
-  return false
+;Execute wind-in frames in winder and push onto state.
+defn wind-in (winder:DyCtxtWinder, c:RawCoroutine) -> False :
+  if not empty?(winder) :
+    defn* pop-next-frame (cos:List<RawCoroutine>) :
+      if not empty?(winder) :
+        val entry = pop(winder)
+        exec-frame(cos, key(entry), value(entry))
+    defn* exec-frame (cos:List<RawCoroutine>, co-id:Int, frame:DyCtxtFrame) :
+      val co = head(cos)
+      if id(co) == co-id :        
+        push-frame(dy-ctxt-state(co), frame)
+        pop-next-frame(cos)
+      else :
+        exec-frame(tail(cos), co-id, frame)
+    val entry0 = peek(winder)
+    pop-next-frame(reverse(collect-parents(c, key(entry0))))
 
-;Wind in a frame pack.
-lostanza defn wind-in (pack:ref<DyCtxtPack>) -> ref<False> :
-  val len = pack.length
-  for (var i:long = 0, i < len, i = i + 1) :
-    push-dy-ctxt-frame(pack.frames[i])
-  return false
+;Execute the given body with the given frame pushed into
+;the dynamic context of the current coroutine.
+defn dynamic-wind<?T> (body:() -> ?T,
+                       frame:DyCtxtFrame) -> T :
+  val s = dy-ctxt-state(current-coroutine)
+  push-frame(s, frame)
+  val result = body()
+  pop-frame(s, true, true)
+  result
 
-;Wind in only the finally frames.
-lostanza defn wind-in-finally (pack:ref<DyCtxtPack>) -> ref<False> :
-  val len = pack.length
-  for (var i:long = 0, i < len, i = i + 1) :
-    if pack.frames[i].finally? :
-      push-dy-ctxt-frame(pack.frames[i])    
-  return false  
-
-;Error message for fatal.
-defn empty-dy-stack (id:Int) :
-  "Expecting dynamic frame with id %_, but dynamic \
-   context stack is empty." % [id]
-defn wrong-dy-stack (id:Int, actual:Int) :
-  "Expecting dynamic frame with id %_, but top of dynamic \
-   context stack is frame %_." % [id, actual]
-
-;Pop a specific dynamic context frame.
-;defstruct Winder :
-;  in: False|(() -> ?)
-;  out: False|(() -> ?)
-;  final: False|(() -> ?)
-;
-;var WINDER-STACK:List<Winder>
-;var NUM-WINDERS:Int
-;
-;defn initialize-winders () :
-;  WINDER-STACK = List()
-;  NUM-WINDERS = 0
-;
-;defn pop-winder () :
-;  val w = head(WINDER-STACK)
-;  WINDER-STACK = tail(WINDER-STACK)
-;  NUM-WINDERS = NUM-WINDERS - 1
-;  w
-;
-;defn push-winder (w:Winder) :
-;  WINDER-STACK = cons(w, WINDER-STACK)
-;  NUM-WINDERS = NUM-WINDERS + 1
-;
-;defn pop-winders (n:Int) :
-;  defn pop (n:Int) :
-;    if n > 0 : cons(pop-winder(), pop(n - 1))
-;    else : List()
-;  pop(NUM-WINDERS - n)
-;
-;defn push-winders (ws:List<Winder>) :
-;  if not empty?(ws) :
-;    push-winders(tail(ws))
-;    push-winder(head(ws))
-;
-;defn total-winders (c:False|RawCoroutine) -> Int :
-;  match(c) :
-;    (c:False) : 0
-;    (c:RawCoroutine) : total-winders(parent(c)) + num-winders(c)
-;
-;defn wind-in (ws:List<Winder>) :
-;  if not empty?(ws) :
-;    wind-in(tail(ws))
-;    call?(in(head(ws)))
-;
-;defn wind-out (ws:List<Winder>, call-out:True|False, call-final:True|False) :
-;  if not empty?(ws) :
-;    call?(out(head(ws))) when call-out
-;    call?(final(head(ws))) when call-final
-;    wind-out(tail(ws), call-out, call-final)
-;
-;defn* call? (f: False|(() -> ?)) :
-;  match(f) :
-;    (f:() -> ?) : f()
-;    (f:False) : false
-;
-;lostanza defn inc-winders (c:ref<RawCoroutine>, n:ref<Int>) -> ref<False> :
-;  c.num-winders = c.num-winders + n.value
-;  return false
-;
-;lostanza defn num-winders (c:ref<RawCoroutine>) -> ref<Int> :
-;  return new Int{c.num-winders}
-
+;Execute the given body within the given dynamic context.
 public defn dynamic-wind<?T> (in:False|(() -> ?),
                               body:() -> ?T,
                               out:False|(() -> ?)) -> T :
-  val frame = DyCtxtFrame(in, out)
-  push-dy-ctxt-frame(frame)
-  val result = body()
-  pop-dy-ctxt-frame(frame, true, true)
-  result
+  dynamic-wind(body, DyCtxtFrame(in, out))
 
-;  call?(in*)
-;  push-winder(Winder(in*, out*, false))
-;  inc-winders(current-coroutine, 1)
-;  val result = body()
-;  pop-winder()
-;  inc-winders(current-coroutine, -1)
-;  call?(out*)
-;  result
+;Wind in and then wind out of all entries in the given winder.
+;Used to force finally blocks to run.
+defn wind-in-out (winder:DyCtxtWinder) -> False :
+  val num = num-finally-blocks(winder)
+  let loop (i:Int = 0) :
+    if i < num :
+      dynamic-wind(loop{i + 1}, value(pop(winder)))
+    false
+
+;Collect parents up to the given parent-id.
+defn collect-parents (c:RawCoroutine, parent-id:Int) -> List<RawCoroutine> :
+  if id(c) == parent-id : List(c)
+  else : cons(c, collect-parents(parent(c) as RawCoroutine, parent-id))
 
 ;============================================================
 ;====================== Coroutines ==========================
@@ -3750,34 +3645,11 @@ protected lostanza deftype RawCoroutine <: Coroutine & Unique :
   var stack: ref<Stack>
   var parent: ref<False|RawCoroutine>
   var status: ref<Int>
-  dy-ctxt-state: ref<DyCtxtState>
   var crsp: long
-  saved-finally: ref<SavedFinally>
+  dy-ctxt-state: ref<DyCtxtState>
 
-;When a coroutine is garbage-collected or closed, we need to
-;execute its finally blocks. 
-;- attached-finalizer?: Gets set to true when we create a finalizer.
-lostanza deftype SavedFinally <: Finalizer :
-  var pack: ref<DyCtxtPack|False>
-  var registered?: ref<True|False>
-
-lostanza defn save-pack (saved:ref<SavedFinally>,
-                         pack:ref<DyCtxtPack>,
-                         c:ref<RawCoroutine>) -> ref<False> :
-  if contains-finally?(pack) :
-    saved.pack = pack
-    if saved.registered? == false :
-      saved.registered? = true
-      add-finalizer(saved, c)
-  return false
-
-lostanza defmethod run (f:ref<SavedFinally>) -> ref<False> :
-  val pack = f.pack
-  if pack != false :
-    val pack = pack as ref<DyCtxtPack>
-    wind-in-finally(pack)
-    wind-out(pack, false, true)
-  return false
+lostanza defn dy-ctxt-state (co:ref<RawCoroutine>) -> ref<DyCtxtState> :
+  return co.dy-ctxt-state
 
 lostanza deftype CoroutineParams :
   parent-stack: ref<Stack>
@@ -3796,9 +3668,8 @@ lostanza defn initialize-coroutines () -> ref<False> :
                         current-stack,
                         false,
                         COROUTINE-ACTIVE,
-                        new DyCtxtState{0, 0, 0},
                         crsp,
-                        new SavedFinally{false, false}}
+                        DyCtxtState()}
   COROUTINE-COUNTER = 1L
   return false
 
@@ -3831,9 +3702,8 @@ lostanza defn* setup-coroutine (stack:ref<Stack>, parent-stack:ref<Stack>, enter
                  stack,
                  false,
                  COROUTINE-OPEN,
-                 new DyCtxtState{0, 0, 0},
                  crsp,
-                 new SavedFinally{false, false}}
+                 DyCtxtState()}
   COROUTINE-COUNTER = COROUTINE-COUNTER + 1L
   val x0 = call-prim yield(parent-stack, co)
   return break(co, [enter](co, x0))
@@ -3890,12 +3760,11 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
 
   ;Retrieve the pack of frames since parent was last exited,
   ;and wind out.
-  val pack = dynamic-context-pack(c.dy-ctxt-state)
-  wind-out(pack, true, false)
+  val winder = DyCtxtWinder()
+  wind-out(current-coroutine, winder, id(c), true, false)
 
-  ;Save the dynamic context pack in case we need to
-  ;run its finally blocks later.
-  save-pack(c.saved-finally, pack, c)
+  ;Save the winders in case we need to run its finally blocks later.
+  save-winders(c, winder)
 
   ;Detach coroutine
   detach-coroutine(c, COROUTINE-OPEN)
@@ -3903,8 +3772,11 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Return to resume
   val result = call-prim yield(current-coroutine.stack, x)
 
+  ;Clear winders so now the coroutine is attached again.
+  clear-winders(c)
+
   ;Wind in the dynamic context state.
-  wind-in(pack)
+  wind-in(winder, current-coroutine)
 
   ;Return execution
   return result
@@ -3919,11 +3791,7 @@ lostanza defmethod close (c:ref<RawCoroutine>) -> ref<False> :
     return fatal("Cannot close coroutine. Coroutine's parent is suspended.")
 
   ;Execute the finally blocks.
-  if c.saved-finally.pack != false :
-    val pack = c.saved-finally.pack as ref<DyCtxtPack>
-    c.saved-finally.pack = false
-    wind-in-finally(pack)
-    wind-out(pack, false, true)
+  run(c.dy-ctxt-state)
 
   free-coroutine(c)
   return false
@@ -3942,8 +3810,8 @@ lostanza defmethod break (c:ref<RawCoroutine>, x:ref<?>) -> ref<Void> :
 
   ;Retrieve the pack of frames since parent was last exited,
   ;and wind out.
-  val pack = dynamic-context-pack(c.dy-ctxt-state)
-  wind-out(pack, true, true)
+  val winder = DyCtxtWinder()
+  wind-out(current-coroutine, winder, id(c), true, true)
 
 ;  call-c clib/printf("[%ld] Wind out\n", stack-id)
 ;
@@ -3983,18 +3851,7 @@ lostanza defn free-coroutine (c:ref<RawCoroutine>) -> int :
         (p:ref<RawCoroutine>) : goto loop(p)
         (p:ref<False>) : return 0
 
-lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :
-  ;Store current state of dynamic context in c.
-  store-current-dynamic-context-state(c.dy-ctxt-state)
-
-  ;Now that cc is being closed off, compute its final number of frames.
-  val cc = current-coroutine
-  cc.dy-ctxt-state.num-frames = c.dy-ctxt-state.length - cc.dy-ctxt-state.length
-
-  ;Now that the coroutine is attached again, discard its saved finally
-  ;blocks.
-  c.saved-finally.pack = false
-  
+lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :  
   labels :
     begin :
       goto loop(c)
@@ -4005,14 +3862,8 @@ lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :
       c.crsp = call-prim crsp() as long
       current-coroutine = c
       match(p) :
-        (p:ref<RawCoroutine>) :
-          ;We now know the parent's dynamic context state.
-          p.dy-ctxt-state.length = c.dy-ctxt-state.length + c.dy-ctxt-state.num-frames
-          if c.dy-ctxt-state.num-frames == 0 :
-            p.dy-ctxt-state.top = c.dy-ctxt-state.top
-          goto loop(p)
-        (p:ref<False>) :
-          return 0
+        (p:ref<RawCoroutine>) : goto loop(p)
+        (p:ref<False>) : return 0
 
 ;Implements the semantics of suspending with 'c' as the argument coroutine.
 ;This function follows the parent pointer of the current coroutine until it reaches
@@ -4180,8 +4031,6 @@ protected val uninitialized = new Uninitialized
 
 initialize-error-handler()
 initialize-command-launcher()
-;initialize-winders()
-initialize-dynamic-contexts()
 initialize-coroutines()
 initialize-gc-notifiers()
 initialize-liveness-handlers()
@@ -6284,10 +6133,11 @@ defstruct NormalResult : (result)
 
 ;Run the given body with the equipped finally block.
 public defn with-finally<?T> (body: () -> ?T, finally: () -> ?) -> T :
+  val s = dy-ctxt-state(current-coroutine)
   val frame = DyCtxtFinallyFrame(finally)
-  push-dy-ctxt-frame(frame)
+  push-frame(s, frame)
   val result = body()
-  pop-dy-ctxt-frame(frame, true, true)
+  pop-frame(s, true, true)
   result
 
 

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3405,80 +3405,278 @@ defmethod length (x:List) :
   loop(x, 0)
 
 ;============================================================
-;=================== Winders ================================
+;=================== Dynamic Context ========================
 ;============================================================
-defstruct Winder :
-  in: False|(() -> ?)
-  out: False|(() -> ?)
-  final: False|(() -> ?)
 
-var WINDER-STACK:List<Winder>
-var NUM-WINDERS:Int
+;A counter for generating ids for dynamic context frames.
+var DYNAMIC-CONTEXT-COUNTER:Seq<Int>
 
-defn initialize-winders () :
-  WINDER-STACK = List()
-  NUM-WINDERS = 0
+;Global stack of dynamic contexts.
+var DYNAMIC-CONTEXTS:Vector<DyCtxtFrame>
 
-defn pop-winder () :
-  val w = head(WINDER-STACK)
-  WINDER-STACK = tail(WINDER-STACK)
-  NUM-WINDERS = NUM-WINDERS - 1
-  w
+;Initialize the global variables necessary for
+;tracking dynamic contexts.
+defn initialize-dynamic-contexts () :
+  DYNAMIC-CONTEXT-COUNTER = to-seq(0 to false)
+  DYNAMIC-CONTEXTS = Vector<DyCtxtFrame>()
 
-defn push-winder (w:Winder) :
-  WINDER-STACK = cons(w, WINDER-STACK)
-  NUM-WINDERS = NUM-WINDERS + 1
+;Represents a new dynamic context frame.
+lostanza deftype DyCtxtFrame :
+  id:int
+  finally?:int
+  in: ref<False|(() -> ?)>
+  out: ref<False|(() -> ?)>
 
-defn pop-winders (n:Int) :
-  defn pop (n:Int) :
-    if n > 0 : cons(pop-winder(), pop(n - 1))
-    else : List()
-  pop(NUM-WINDERS - n)
+lostanza defn id (f:ref<DyCtxtFrame>) -> ref<Int> :
+  return new Int{f.id}
+lostanza defn finally? (f:ref<DyCtxtFrame>) -> ref<True|False> :
+  if f.finally? : return true
+  else : return false
+lostanza defn in (f:ref<DyCtxtFrame>) -> ref<False|(() -> ?)> :
+  return f.in
+lostanza defn out (f:ref<DyCtxtFrame>) -> ref<False|(() -> ?)> :
+  return f.out
 
-defn push-winders (ws:List<Winder>) :
-  if not empty?(ws) :
-    push-winders(tail(ws))
-    push-winder(head(ws))
+public defn print-dynamic-contexts () :
+  println("Dynamic Context:")
+  for f in in-reverse(DYNAMIC-CONTEXTS) do :
+    print("  ")
+    println(f)
 
-defn total-winders (c:False|RawCoroutine) -> Int :
-  match(c) :
-    (c:False) : 0
-    (c:RawCoroutine) : total-winders(parent(c)) + num-winders(c)
+defmethod print (o:OutputStream, f:DyCtxtFrame) :
+  val in-str = " " when in(f) is False else "^"
+  val out-str = " " when out(f) is False else "v"
+  val f-str = "F" when finally?(f) else " "
+  print(o, "[%_ | %_ | %_ %_]" % [id(f), in-str, out-str, f-str])
 
-defn wind-in (ws:List<Winder>) :
-  if not empty?(ws) :
-    wind-in(tail(ws))
-    call?(in(head(ws)))
+;Create a new non-finally dynamic context frame.
+lostanza defn DyCtxtFrame (in:ref<False|(() -> ?)>,
+                           out:ref<False|(() -> ?)>) -> ref<DyCtxtFrame> :
+  return new DyCtxtFrame{
+           next(DYNAMIC-CONTEXT-COUNTER).value
+           0,
+           in,
+           out}
 
-defn wind-out (ws:List<Winder>, call-out:True|False, call-final:True|False) :
-  if not empty?(ws) :
-    call?(out(head(ws))) when call-out
-    call?(final(head(ws))) when call-final
-    wind-out(tail(ws), call-out, call-final)
+;Create a new finally dynamic context frame.
+lostanza defn DyCtxtFinallyFrame (f:ref<(() -> ?)>) -> ref<DyCtxtFrame> :
+  return new DyCtxtFrame{
+           next(DYNAMIC-CONTEXT-COUNTER).value
+           1,
+           false,
+           f}
 
-defn* call? (f: False|(() -> ?)) :
-  match(f) :
-    (f:() -> ?) : f()
-    (f:False) : false
+;Represents the state of the dynamic context stack.
+;- length: The number of active dynamic frames when this coroutine was
+;  resumed.
+;- top: The top-most frame when this coroutine was resumed.
+;- num-frames: If not the top-most coroutine, the number of frames in the coroutine.
+;  Otherwise -1.
+lostanza deftype DyCtxtState :
+  var length:int
+  var top:int
+  var num-frames:int
 
-lostanza defn inc-winders (c:ref<RawCoroutine>, n:ref<Int>) -> ref<False> :
-  c.num-winders = c.num-winders + n.value
+;Represents a pack of dynamic context frames.
+lostanza deftype DyCtxtPack :
+  length:long
+  var frames:ref<DyCtxtFrame> ...
+
+lostanza defn length (p:ref<DyCtxtPack>) -> ref<Int> : 
+  return new Int{p.length as int}
+
+lostanza defn get (p:ref<DyCtxtPack>, i:ref<Int>) -> ref<DyCtxtFrame> :
+  return p.frames[i.value]
+
+defmethod print (o:OutputStream, p:DyCtxtPack) :
+  val n = length(p)
+  if n == 0 :
+    print(o, "DyCtxtPack: ()")
+  else :
+    print(o, "DyCtxtPack:")
+    for i in reverse(0 to length(p)) do :
+      lnprint(o, "  %_" % [p[i]])
+
+;Retrieve the current state of the dynamic context stack.
+;Used for when a Coroutine is created.
+lostanza defn current-dynamic-context-state (s:ref<DyCtxtState>) -> ref<False> :
+  val len = length(DYNAMIC-CONTEXTS).value
+  s.length = len
+  if len > 0 : s.top = peek(DYNAMIC-CONTEXTS).id
+  else : s.top = 0
   return false
 
-lostanza defn num-winders (c:ref<RawCoroutine>) -> ref<Int> :
-  return new Int{c.num-winders}
+;Retrieve the top-n frames on the dynamic context stack, and return
+;the frames as a pack.
+lostanza defn dynamic-context-pack (state:ref<DyCtxtState>) -> ref<DyCtxtPack> :
+  ensure-consistent-state(state)
+  val num-frames = length(DYNAMIC-CONTEXTS).value
+  val pack-length = num-frames - state.length
+  if pack-length == 0 :
+    return EMPTY-DY-CTXT-PACK
+  else :
+    val start = state.length
+    val frame0 = get(DYNAMIC-CONTEXTS, new Int{start})
+    val pack = new DyCtxtPack{pack-length, frame0}
+    for (var i:long = 1, i < pack-length, i = i + 1) :
+      pack.frames[i] = frame0
+    for (var i:int = 1, i < pack-length, i = i + 1) :
+      pack.frames[i] = get(DYNAMIC-CONTEXTS, new Int{start + i})
+    return pack
+
+lostanza defn ensure-consistent-state (s:ref<DyCtxtState>) -> ref<False> :
+  ;Ensure the length is proper.
+  if s.length > length(DYNAMIC-CONTEXTS).value :
+    fatal(larger-state-than-expected(new Int{s.length}, length(DYNAMIC-CONTEXTS)))
+  ;Ensure the frame id is expected.
+  if s.length > 0 :
+    val f = get(DYNAMIC-CONTEXTS, new Int{s.length - 1})
+    if f.id != s.top :
+      fatal(wrong-dy-state(new Int{s.top}, new Int{f.id}))
+  return false
+
+defn larger-state-than-expected (expected:Int, actual:Int) :
+  "Expected length of dynamic context stack is %_, but actual \
+   length is %_." % [expected, actual]
+   
+defn wrong-dy-state (expected:Int, actual:Int) :
+  "Expected frame id is %_, but actual frame is %_." % [expected, actual]
+
+lostanza val EMPTY-DY-CTXT-PACK:ref<DyCtxtPack> = new DyCtxtPack{0}
+
+;Push a single dynamic context frame after we execute it.
+lostanza defn push-dy-ctxt-frame (f:ref<DyCtxtFrame>) -> ref<False> :
+  if f.in != false :
+    val f-in = f.in as ref<(() -> ?)>
+    [f-in]()
+  add(DYNAMIC-CONTEXTS, f)
+  return false
+
+;Pop a single dynamic context frame and then execute it.
+lostanza defn pop-dy-ctxt-frame (f:ref<DyCtxtFrame>,
+                                 call-out?:ref<True|False>,
+                                 call-finally?:ref<True|False>) -> ref<False> :
+  ;Check sanity frame.
+  if empty?(DYNAMIC-CONTEXTS) == true :
+    fatal(empty-dy-stack(new Int{f.id}))
+  if peek(DYNAMIC-CONTEXTS).id != f.id :
+    val top = peek(DYNAMIC-CONTEXTS)
+    fatal(wrong-dy-stack(new Int{f.id}, new Int{top.id}))
+
+  ;Pop the top frame.
+  pop(DYNAMIC-CONTEXTS)
+
+  ;Call the frame out if requested.
+  if f.out != false :
+    val f-out = f.out as ref<(() -> ?)>
+    if f.finally? :
+      if call-finally? == true : [f-out]()
+    else :
+      if call-out? == true : [f-out]()
+  return false
+
+;Wind out a frame pack.
+lostanza defn wind-out (pack:ref<DyCtxtPack>,
+                        call-out?:ref<True|False>
+                        call-finally?:ref<True|False>) -> ref<False> :
+  for (var i:long = pack.length - 1, i >= 0, i = i - 1) :
+    pop-dy-ctxt-frame(pack.frames[i], call-out?, call-finally?)
+  return false
+
+;Wind in a frame pack.
+lostanza defn wind-in (pack:ref<DyCtxtPack>) -> ref<False> :
+  val len = pack.length
+  for (var i:long = 0, i < len, i = i + 1) :
+    push-dy-ctxt-frame(pack.frames[i])
+  return false
+
+;Error message for fatal.
+defn empty-dy-stack (id:Int) :
+  "Expecting dynamic frame with id %_, but dynamic \
+   context stack is empty." % [id]
+defn wrong-dy-stack (id:Int, actual:Int) :
+  "Expecting dynamic frame with id %_, but top of dynamic \
+   context stack is frame %_." % [id, actual]
+
+;Pop a specific dynamic context frame.
+;defstruct Winder :
+;  in: False|(() -> ?)
+;  out: False|(() -> ?)
+;  final: False|(() -> ?)
+;
+;var WINDER-STACK:List<Winder>
+;var NUM-WINDERS:Int
+;
+;defn initialize-winders () :
+;  WINDER-STACK = List()
+;  NUM-WINDERS = 0
+;
+;defn pop-winder () :
+;  val w = head(WINDER-STACK)
+;  WINDER-STACK = tail(WINDER-STACK)
+;  NUM-WINDERS = NUM-WINDERS - 1
+;  w
+;
+;defn push-winder (w:Winder) :
+;  WINDER-STACK = cons(w, WINDER-STACK)
+;  NUM-WINDERS = NUM-WINDERS + 1
+;
+;defn pop-winders (n:Int) :
+;  defn pop (n:Int) :
+;    if n > 0 : cons(pop-winder(), pop(n - 1))
+;    else : List()
+;  pop(NUM-WINDERS - n)
+;
+;defn push-winders (ws:List<Winder>) :
+;  if not empty?(ws) :
+;    push-winders(tail(ws))
+;    push-winder(head(ws))
+;
+;defn total-winders (c:False|RawCoroutine) -> Int :
+;  match(c) :
+;    (c:False) : 0
+;    (c:RawCoroutine) : total-winders(parent(c)) + num-winders(c)
+;
+;defn wind-in (ws:List<Winder>) :
+;  if not empty?(ws) :
+;    wind-in(tail(ws))
+;    call?(in(head(ws)))
+;
+;defn wind-out (ws:List<Winder>, call-out:True|False, call-final:True|False) :
+;  if not empty?(ws) :
+;    call?(out(head(ws))) when call-out
+;    call?(final(head(ws))) when call-final
+;    wind-out(tail(ws), call-out, call-final)
+;
+;defn* call? (f: False|(() -> ?)) :
+;  match(f) :
+;    (f:() -> ?) : f()
+;    (f:False) : false
+;
+;lostanza defn inc-winders (c:ref<RawCoroutine>, n:ref<Int>) -> ref<False> :
+;  c.num-winders = c.num-winders + n.value
+;  return false
+;
+;lostanza defn num-winders (c:ref<RawCoroutine>) -> ref<Int> :
+;  return new Int{c.num-winders}
 
 public defn dynamic-wind<?T> (in:False|(() -> ?),
                               body:() -> ?T,
                               out:False|(() -> ?)) -> T :
-  call?(in)
-  push-winder(Winder(in, out, false))
-  inc-winders(current-coroutine, 1)
+  val frame = DyCtxtFrame(in, out)
+  push-dy-ctxt-frame(frame)
   val result = body()
-  pop-winder()
-  inc-winders(current-coroutine, -1)
-  call?(out)
+  pop-dy-ctxt-frame(frame, true, true)
   result
+
+;  call?(in*)
+;  push-winder(Winder(in*, out*, false))
+;  inc-winders(current-coroutine, 1)
+;  val result = body()
+;  pop-winder()
+;  inc-winders(current-coroutine, -1)
+;  call?(out*)
+;  result
 
 ;============================================================
 ;====================== Coroutines ==========================
@@ -3538,19 +3736,19 @@ protected lostanza deftype RawCoroutine <: Coroutine & Unique :
   var stack: ref<Stack>
   var parent: ref<False|RawCoroutine>
   var status: ref<Int>
-  var num-winders: int
+  dy-ctxt-state: ref<DyCtxtState>
   var crsp: long
-  saved-winders: ref<SavedWinders>
+;  saved-winders: ref<SavedWinders>
 
 ;- attached-finalizer? is false by default, and is marked as true
 ;  when winders is set to a list that contains at least one Winder
 ;  with a final callback.
-lostanza deftype SavedWinders :
-  var winders: ref<List<Winder>>
-  var attached-finalizer?: ref<True|False>
+;lostanza deftype SavedWinders :
+;  var winders: ref<List<Winder>>
+;  var attached-finalizer?: ref<True|False>
 
-lostanza deftype WinderFinalizer <: Finalizer :
-  saved-winders: ref<SavedWinders>
+;lostanza deftype WinderFinalizer <: Finalizer :
+;  saved-winders: ref<SavedWinders>
 
 lostanza deftype CoroutineParams :
   parent-stack: ref<Stack>
@@ -3564,7 +3762,10 @@ lostanza defn initialize-coroutines () -> ref<False> :
   val vms:ptr<VMState> = call-prim flush-vm()
   val current-stack = vms.heap.current-stack as ref<Stack>
   val crsp = call-prim crsp() as long
-  current-coroutine = new RawCoroutine{0L, current-stack, false, COROUTINE-ACTIVE, 0, crsp, new SavedWinders{List(), false}}
+  current-coroutine = new RawCoroutine{0L, current-stack, false,
+                                       COROUTINE-ACTIVE, new DyCtxtState{0, 0, -1}, crsp,
+                                       ;new SavedWinders{List(), false}
+                                       }
   COROUTINE-COUNTER = 1L
   return false
 
@@ -3590,16 +3791,19 @@ lostanza defmethod open? (c:ref<RawCoroutine>) -> ref<True|False> :
   if c.status == COROUTINE-OPEN : return true
   else : return false
 
-lostanza defmethod run (f:ref<WinderFinalizer>) -> ref<False> :
-  val winders = f.saved-winders.winders
-  if empty?(winders) == false :
-    f.saved-winders.winders = List()
-    wind-out(winders, false, true)
-  return false
+;lostanza defmethod run (f:ref<WinderFinalizer>) -> ref<False> :
+;  val winders = f.saved-winders.winders
+;  if empty?(winders) == false :
+;    f.saved-winders.winders = List()
+;    wind-out(winders, false, true)
+;  return false
 
 lostanza defn* setup-coroutine (stack:ref<Stack>, parent-stack:ref<Stack>, enter:ref<((RawCoroutine, ?) -> ?)>) -> ref<?> :
   val crsp = call-prim crsp() as long
-  val co = new RawCoroutine{COROUTINE-COUNTER, stack, false, COROUTINE-OPEN, 0, crsp, new SavedWinders{List(), false}}
+  val co = new RawCoroutine{COROUTINE-COUNTER, stack, false, COROUTINE-OPEN,
+                            new DyCtxtState{0, 0, -1}, crsp,
+                            ;new SavedWinders{List(), false}
+                            }
   COROUTINE-COUNTER = COROUTINE-COUNTER + 1L
   val x0 = call-prim yield(parent-stack, co)
   return break(co, [enter](co, x0))
@@ -3615,7 +3819,7 @@ lostanza defmethod resume (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
 
   ;Adjust state
   attach-coroutine(c)
-
+  
   ;Begin execution
   val result = call-prim yield(current-coroutine.stack, x)
 
@@ -3626,21 +3830,21 @@ lostanza defmethod resume (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Return the result yielded by the coroutine.
   return result
 
-;Return true if any of the given winders has a final callback.
-defn has-final-callback? (winders:List<Winder>) -> True|False :
-  for w in winders any? :
-    final(w) is-not False
+;;Return true if any of the given winders has a final callback.
+;defn has-final-callback? (winders:List<Winder>) -> True|False :
+;  for w in winders any? :
+;    final(w) is-not False
 
 ;If the coroutine's saved winders contains a final callback and a
 ;finalizer has not been attached to run them when the coroutine
 ;is collected, then add it now.
-lostanza defn add-winders-finalizer-if-necessary? (c:ref<RawCoroutine>) -> ref<False> :
-  val saved-winders = c.saved-winders
-  if saved-winders.attached-finalizer? == false and
-     has-final-callback?(saved-winders.winders) == true :
-    add-finalizer(new WinderFinalizer{saved-winders}, c)
-    saved-winders.attached-finalizer? = true
-  return false
+;lostanza defn add-winders-finalizer-if-necessary? (c:ref<RawCoroutine>) -> ref<False> :
+;  val saved-winders = c.saved-winders
+;  if saved-winders.attached-finalizer? == false and
+;     has-final-callback?(saved-winders.winders) == true :
+;    add-finalizer(new WinderFinalizer{saved-winders}, c)
+;    saved-winders.attached-finalizer? = true
+;  return false
 
 lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Ensure coroutine is active
@@ -3654,10 +3858,19 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Ensure coroutine was launched within same c context
   ensure-target-in-same-c-ctxt!(c)
 
-  ;Set target winder environment and wind out
-  c.saved-winders.winders = pop-winders(total-winders(c.parent))
-  add-winders-finalizer-if-necessary?(c)
-  wind-out(c.saved-winders.winders, true, false)
+  ;Retrieve the pack of frames since parent was last exited,
+  ;and wind out.
+  val pack = dynamic-context-pack(c.dy-ctxt-state)
+  wind-out(pack, true, false)
+
+;  call-c clib/printf("[%ld] Wind out\n", stack-id)
+;
+;  ;Set target winder environment and wind out
+;  c.saved-winders.winders = pop-winders(total-winders(c.parent))
+;  add-winders-finalizer-if-necessary?(c)
+;  wind-out(c.saved-winders.winders, true, false)
+;
+;  call-c clib/printf("[%ld] Wind outs finished\n", stack-id)
 
   ;Detach coroutine
   detach-coroutine(c, COROUTINE-OPEN)
@@ -3665,17 +3878,20 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   ;Return to resume
   val result = call-prim yield(current-coroutine.stack, x)
 
-  ;Wind in and restore original winder environment
-  val winders = c.saved-winders.winders
-  c.saved-winders.winders = List()
-  wind-in(winders)
-  push-winders(winders)
+  ;Wind in the dynamic context state.
+  wind-in(pack)
+
+;  ;Wind in and restore original winder environment
+;  val winders = c.saved-winders.winders
+;  c.saved-winders.winders = List()
+;  wind-in(winders)
+;  push-winders(winders)
+
 
   ;Return execution
   return result
 
 lostanza defmethod close (c:ref<RawCoroutine>) -> ref<False> :
-  ;call-c clib/printf("[from coroutine %d] closing coroutine %d\n", current-coroutine.id, c.id)
   ;Ensure coroutine is re-entrant
   if c.status == COROUTINE-CLOSED :
     return fatal("Cannot close coroutine. Coroutine is already closed.")
@@ -3685,10 +3901,10 @@ lostanza defmethod close (c:ref<RawCoroutine>) -> ref<False> :
     return fatal("Cannot close coroutine. Coroutine's parent is suspended.")
 
   ;Execute any final winders if necessary
-  val winders = c.saved-winders.winders
-  if empty?(winders) == false :
-    c.saved-winders.winders = List()
-    wind-out(winders, false, true)
+  ;val winders = c.saved-winders.winders
+  ;if empty?(winders) == false :
+  ;  c.saved-winders.winders = List()
+  ;  wind-out(winders, false, true)
 
   free-coroutine(c)
   return false
@@ -3705,9 +3921,18 @@ lostanza defmethod break (c:ref<RawCoroutine>, x:ref<?>) -> ref<Void> :
   ;Ensure coroutine was launched within same c context
   ensure-target-in-same-c-ctxt!(c)
 
-  ;Set target winder environment and wind out
-  val winders = pop-winders(total-winders(c.parent))
-  wind-out(winders, true, true)
+  ;Retrieve the pack of frames since parent was last exited,
+  ;and wind out.
+  val pack = dynamic-context-pack(c.dy-ctxt-state)
+  wind-out(pack, true, true)
+
+;  call-c clib/printf("[%ld] Wind out\n", stack-id)
+;
+;  ;Set target winder environment and wind out
+;  val winders = pop-winders(total-winders(c.parent))
+;  wind-out(winders, true, true)
+;
+;  call-c clib/printf("[%ld] Wind outs finished\n", stack-id)
 
   ;Adjust state
   detach-coroutine(c, COROUTINE-CLOSED)
@@ -3740,6 +3965,11 @@ lostanza defn free-coroutine (c:ref<RawCoroutine>) -> int :
         (p:ref<False>) : return 0
 
 lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :
+  ;Update dynamic context information of c and current-coroutine.
+  current-dynamic-context-state(c.dy-ctxt-state)
+  val cc = current-coroutine
+  cc.dy-ctxt-state.num-frames = c.dy-ctxt-state.length - cc.dy-ctxt-state.length
+  
   labels :
     begin :
       goto loop(c)
@@ -3750,8 +3980,14 @@ lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :
       c.crsp = call-prim crsp() as long
       current-coroutine = c
       match(p) :
-        (p:ref<RawCoroutine>) : goto loop(p)
-        (p:ref<False>) : return 0
+        (p:ref<RawCoroutine>) :
+          ;We now know the parent's dynamic context state.
+          p.dy-ctxt-state.length = c.dy-ctxt-state.length + c.dy-ctxt-state.num-frames
+          if c.dy-ctxt-state.num-frames == 0 :
+            p.dy-ctxt-state.top = c.dy-ctxt-state.top
+          goto loop(p)
+        (p:ref<False>) :
+          return 0
 
 ;Implements the semantics of suspending with 'c' as the argument coroutine.
 ;This function follows the parent pointer of the current coroutine until it reaches
@@ -3919,7 +4155,8 @@ protected val uninitialized = new Uninitialized
 
 initialize-error-handler()
 initialize-command-launcher()
-initialize-winders()
+;initialize-winders()
+initialize-dynamic-contexts()
 initialize-coroutines()
 initialize-gc-notifiers()
 initialize-liveness-handlers()
@@ -5961,6 +6198,8 @@ var CURRENT-EXCEPTION-HANDLER : Exception -> Void =
   fn (e:Exception) :
     fatal(e)
 
+public var CURRENT-HANDLER-NAME:String = "Default"
+
 ;Throw the given exception to the currently-set handler.
 public defn throw (e:Exception) :
   CURRENT-EXCEPTION-HANDLER(e)
@@ -5981,9 +6220,9 @@ public defn with-exception-handler<?T> (body: () -> ?T,
                                         catcher: Exception -> ?T) -> T :
   ;Execute the body within a label so that stack can be unwound.
   val r = label<ExceptionResult|NormalResult> break :
-    ;Get the current handler. This needs to be called if the
-    ;equipped catcher doesn't handle this.
-    val current-handler = CURRENT-EXCEPTION-HANDLER
+    ;Holds the outer handler during the dynamic extent of this 'try' block.
+    ;Will be set during wind-in.
+    var outer-handler:Exception -> Void
 
     ;Implementation of throw within the body.
     defn throw-within-body (e:Exception) :
@@ -5995,11 +6234,17 @@ public defn with-exception-handler<?T> (body: () -> ?T,
       else :
         ;Otherwise, pass the exception to the next handler
         ;to handle it.
-        current-handler(e)
+        outer-handler(e)
 
     ;Execute the body with the new throw equipped.
-    let-var CURRENT-EXCEPTION-HANDLER = throw-within-body :
-      NormalResult(body())
+    dynamic-wind(
+      fn () :
+        outer-handler = CURRENT-EXCEPTION-HANDLER
+        CURRENT-EXCEPTION-HANDLER = throw-within-body
+      fn () :
+        NormalResult(body())
+      fn () :
+        CURRENT-EXCEPTION-HANDLER = outer-handler)
 
   ;Depending on whether the body executed successfully, either
   ;run the catcher or not.
@@ -6014,13 +6259,20 @@ defstruct NormalResult : (result)
 
 ;Run the given body with the equipped finally block.
 public defn with-finally<?T> (body: () -> ?T, finally: () -> ?) -> T :
-  push-winder(Winder(false, false, finally))
-  inc-winders(current-coroutine, 1)
+  val frame = DyCtxtFinallyFrame(finally)
+  push-dy-ctxt-frame(frame)
   val result = body()
-  pop-winder()
-  inc-winders(current-coroutine, -1)
-  finally()
+  pop-dy-ctxt-frame(frame, true, true)
   result
+
+
+;  push-winder(Winder(false, false, finally))
+;  inc-winders(current-coroutine, 1)
+;  val result = body()
+;  pop-winder()
+;  inc-winders(current-coroutine, -1)
+;  finally()
+;  result
 
 ;============================================================
 ;============== Input/Output Exceptions =====================

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -3470,8 +3470,7 @@ lostanza defn DyCtxtFinallyFrame (f:ref<(() -> ?)>) -> ref<DyCtxtFrame> :
 ;- length: The number of active dynamic frames when this coroutine was
 ;  resumed.
 ;- top: The top-most frame when this coroutine was resumed.
-;- num-frames: If not the top-most coroutine, the number of frames in the coroutine.
-;  Otherwise -1.
+;- num-frames: The number of frames in the coroutine.
 lostanza deftype DyCtxtState :
   var length:int
   var top:int
@@ -3481,6 +3480,13 @@ lostanza deftype DyCtxtState :
 lostanza deftype DyCtxtPack :
   length:long
   var frames:ref<DyCtxtFrame> ...
+
+lostanza defn contains-finally? (pack:ref<DyCtxtPack>) -> long :
+  val len = pack.length
+  for (var i:long = 0, i < len, i = i + 1) :
+    val f = pack.frames[i]
+    if f.finally? : return 1
+  return 0
 
 lostanza defn length (p:ref<DyCtxtPack>) -> ref<Int> : 
   return new Int{p.length as int}
@@ -3499,7 +3505,7 @@ defmethod print (o:OutputStream, p:DyCtxtPack) :
 
 ;Retrieve the current state of the dynamic context stack.
 ;Used for when a Coroutine is created.
-lostanza defn current-dynamic-context-state (s:ref<DyCtxtState>) -> ref<False> :
+lostanza defn store-current-dynamic-context-state (s:ref<DyCtxtState>) -> ref<False> :
   val len = length(DYNAMIC-CONTEXTS).value
   s.length = len
   if len > 0 : s.top = peek(DYNAMIC-CONTEXTS).id
@@ -3589,6 +3595,14 @@ lostanza defn wind-in (pack:ref<DyCtxtPack>) -> ref<False> :
   for (var i:long = 0, i < len, i = i + 1) :
     push-dy-ctxt-frame(pack.frames[i])
   return false
+
+;Wind in only the finally frames.
+lostanza defn wind-in-finally (pack:ref<DyCtxtPack>) -> ref<False> :
+  val len = pack.length
+  for (var i:long = 0, i < len, i = i + 1) :
+    if pack.frames[i].finally? :
+      push-dy-ctxt-frame(pack.frames[i])    
+  return false  
 
 ;Error message for fatal.
 defn empty-dy-stack (id:Int) :
@@ -3738,17 +3752,32 @@ protected lostanza deftype RawCoroutine <: Coroutine & Unique :
   var status: ref<Int>
   dy-ctxt-state: ref<DyCtxtState>
   var crsp: long
-;  saved-winders: ref<SavedWinders>
+  saved-finally: ref<SavedFinally>
 
-;- attached-finalizer? is false by default, and is marked as true
-;  when winders is set to a list that contains at least one Winder
-;  with a final callback.
-;lostanza deftype SavedWinders :
-;  var winders: ref<List<Winder>>
-;  var attached-finalizer?: ref<True|False>
+;When a coroutine is garbage-collected or closed, we need to
+;execute its finally blocks. 
+;- attached-finalizer?: Gets set to true when we create a finalizer.
+lostanza deftype SavedFinally <: Finalizer :
+  var pack: ref<DyCtxtPack|False>
+  var registered?: ref<True|False>
 
-;lostanza deftype WinderFinalizer <: Finalizer :
-;  saved-winders: ref<SavedWinders>
+lostanza defn save-pack (saved:ref<SavedFinally>,
+                         pack:ref<DyCtxtPack>,
+                         c:ref<RawCoroutine>) -> ref<False> :
+  if contains-finally?(pack) :
+    saved.pack = pack
+    if saved.registered? == false :
+      saved.registered? = true
+      add-finalizer(saved, c)
+  return false
+
+lostanza defmethod run (f:ref<SavedFinally>) -> ref<False> :
+  val pack = f.pack
+  if pack != false :
+    val pack = pack as ref<DyCtxtPack>
+    wind-in-finally(pack)
+    wind-out(pack, false, true)
+  return false
 
 lostanza deftype CoroutineParams :
   parent-stack: ref<Stack>
@@ -3762,10 +3791,14 @@ lostanza defn initialize-coroutines () -> ref<False> :
   val vms:ptr<VMState> = call-prim flush-vm()
   val current-stack = vms.heap.current-stack as ref<Stack>
   val crsp = call-prim crsp() as long
-  current-coroutine = new RawCoroutine{0L, current-stack, false,
-                                       COROUTINE-ACTIVE, new DyCtxtState{0, 0, -1}, crsp,
-                                       ;new SavedWinders{List(), false}
-                                       }
+  current-coroutine = new RawCoroutine{
+                        0L,
+                        current-stack,
+                        false,
+                        COROUTINE-ACTIVE,
+                        new DyCtxtState{0, 0, 0},
+                        crsp,
+                        new SavedFinally{false, false}}
   COROUTINE-COUNTER = 1L
   return false
 
@@ -3791,19 +3824,16 @@ lostanza defmethod open? (c:ref<RawCoroutine>) -> ref<True|False> :
   if c.status == COROUTINE-OPEN : return true
   else : return false
 
-;lostanza defmethod run (f:ref<WinderFinalizer>) -> ref<False> :
-;  val winders = f.saved-winders.winders
-;  if empty?(winders) == false :
-;    f.saved-winders.winders = List()
-;    wind-out(winders, false, true)
-;  return false
-
 lostanza defn* setup-coroutine (stack:ref<Stack>, parent-stack:ref<Stack>, enter:ref<((RawCoroutine, ?) -> ?)>) -> ref<?> :
   val crsp = call-prim crsp() as long
-  val co = new RawCoroutine{COROUTINE-COUNTER, stack, false, COROUTINE-OPEN,
-                            new DyCtxtState{0, 0, -1}, crsp,
-                            ;new SavedWinders{List(), false}
-                            }
+  val co = new RawCoroutine{
+                 COROUTINE-COUNTER,
+                 stack,
+                 false,
+                 COROUTINE-OPEN,
+                 new DyCtxtState{0, 0, 0},
+                 crsp,
+                 new SavedFinally{false, false}}
   COROUTINE-COUNTER = COROUTINE-COUNTER + 1L
   val x0 = call-prim yield(parent-stack, co)
   return break(co, [enter](co, x0))
@@ -3863,14 +3893,9 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
   val pack = dynamic-context-pack(c.dy-ctxt-state)
   wind-out(pack, true, false)
 
-;  call-c clib/printf("[%ld] Wind out\n", stack-id)
-;
-;  ;Set target winder environment and wind out
-;  c.saved-winders.winders = pop-winders(total-winders(c.parent))
-;  add-winders-finalizer-if-necessary?(c)
-;  wind-out(c.saved-winders.winders, true, false)
-;
-;  call-c clib/printf("[%ld] Wind outs finished\n", stack-id)
+  ;Save the dynamic context pack in case we need to
+  ;run its finally blocks later.
+  save-pack(c.saved-finally, pack, c)
 
   ;Detach coroutine
   detach-coroutine(c, COROUTINE-OPEN)
@@ -3880,13 +3905,6 @@ lostanza defmethod* suspend (c:ref<RawCoroutine>, x:ref<?>) -> ref<?> :
 
   ;Wind in the dynamic context state.
   wind-in(pack)
-
-;  ;Wind in and restore original winder environment
-;  val winders = c.saved-winders.winders
-;  c.saved-winders.winders = List()
-;  wind-in(winders)
-;  push-winders(winders)
-
 
   ;Return execution
   return result
@@ -3900,11 +3918,12 @@ lostanza defmethod close (c:ref<RawCoroutine>) -> ref<False> :
   else if c.status == COROUTINE-SUSPENDED :
     return fatal("Cannot close coroutine. Coroutine's parent is suspended.")
 
-  ;Execute any final winders if necessary
-  ;val winders = c.saved-winders.winders
-  ;if empty?(winders) == false :
-  ;  c.saved-winders.winders = List()
-  ;  wind-out(winders, false, true)
+  ;Execute the finally blocks.
+  if c.saved-finally.pack != false :
+    val pack = c.saved-finally.pack as ref<DyCtxtPack>
+    c.saved-finally.pack = false
+    wind-in-finally(pack)
+    wind-out(pack, false, true)
 
   free-coroutine(c)
   return false
@@ -3965,10 +3984,16 @@ lostanza defn free-coroutine (c:ref<RawCoroutine>) -> int :
         (p:ref<False>) : return 0
 
 lostanza defn attach-coroutine (c:ref<RawCoroutine>) -> int :
-  ;Update dynamic context information of c and current-coroutine.
-  current-dynamic-context-state(c.dy-ctxt-state)
+  ;Store current state of dynamic context in c.
+  store-current-dynamic-context-state(c.dy-ctxt-state)
+
+  ;Now that cc is being closed off, compute its final number of frames.
   val cc = current-coroutine
   cc.dy-ctxt-state.num-frames = c.dy-ctxt-state.length - cc.dy-ctxt-state.length
+
+  ;Now that the coroutine is attached again, discard its saved finally
+  ;blocks.
+  c.saved-finally.pack = false
   
   labels :
     begin :

--- a/tests/test-coroutines.stanza
+++ b/tests/test-coroutines.stanza
@@ -1,0 +1,184 @@
+#use-added-syntax(tests)
+defpackage stz/test-coroutines :
+  import core
+  import collections
+
+;Let-var needs to restore current value of variable.
+deftest coroutine-01 :
+  var x:String = "Default X"
+
+  val gen = generate<String> :
+    let-var x = "Generator X" :
+      #ASSERT(x == "Generator X")
+      yield("Hello")
+      #ASSERT(x == "Generator X")
+      yield("My")
+      #ASSERT(x == "Generator X")
+      yield("World")
+
+  #ASSERT(x == "Default X")
+  #ASSERT(next(gen) == "Hello")
+  #ASSERT(x == "Default X")
+  x = "Changed X"
+  #ASSERT(x == "Changed X")
+  #ASSERT(next(gen) == "My")
+  #ASSERT(x == "Changed X")
+  #ASSERT(next(gen) == "World")
+  #ASSERT(x == "Changed X")
+
+;Finally needs to execute.
+deftest coroutine-02 :
+  val out = Vector<String>()
+  
+  val co = Coroutine<False,Int> $ fn (co, x0) :
+    try :
+      try :
+        try :
+          suspend(co, 0)
+          suspend(co, 1)
+          suspend(co, 2)
+          3
+        finally :
+          add(out, "A")
+      finally :
+        add(out, "B")
+    finally :
+      add(out, "C")
+    
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 0)
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 1)
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 2)
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 3)
+  #ASSERT(to-tuple(out) == ["A" "B" "C"] )
+
+;Finally needs to execute.
+deftest coroutine-03 :
+  val out = Vector<String>()
+  
+  val co = Coroutine<False,Int> $ fn (co, x0) :
+    try :
+      try :
+        try :
+          suspend(co, 0)
+          suspend(co, 1)
+          suspend(co, 2)
+          3
+        finally :
+          add(out, "A")
+      finally :
+        add(out, "B")
+    finally :
+      add(out, "C")
+    
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 0)
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 1)
+  #ASSERT(empty?(out))
+  close(co)
+  #ASSERT(to-tuple(out) == ["A" "B" "C"] )
+
+;Finally needs to execute.
+deftest coroutine-04 :
+  val out = Vector<String>()
+  
+  val co = Coroutine<False,Int> $ fn (co, x0) :
+    try :
+      try :
+        try :
+          suspend(co, 0)
+          suspend(co, 1)
+          suspend(co, 2)
+          3
+        finally :
+          add(out, "A")
+          throw(Exception("Exception in Finally"))
+      finally :
+        add(out, "B")
+    finally :
+      add(out, "C")
+    
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 0)
+  #ASSERT(empty?(out))
+  #ASSERT(resume(co,false) == 1)
+  #ASSERT(empty?(out))
+  try :
+    close(co)
+  catch (e) :
+    false
+  #ASSERT(to-tuple(out) == ["A" "B" "C"] )
+
+deftest coroutine-05 :
+
+  defn wrap (body:() -> ?, name:String, exit?:True|False) :
+    dynamic-wind(
+      fn () :
+        println("%_-enter" % [name])
+      body
+      fn () :
+        println("%_-exit" % [name])
+        if exit? :
+          println("EXITING OUT %_-exit" % [name])
+          throw(Exception("EXIT")))
+
+  val gen = generate<String> :
+    try :
+      yield("Hello")
+      yield("This")
+      yield("Is")
+      yield("Dog")      
+    catch (e) :
+      false
+
+  try :
+    #ASSERT(next(gen) == "Hello")
+  catch (e) :
+    false
+
+  try :
+    within wrap("D", true) :
+      #ASSERT(next(gen) == "This")
+  catch (e) :
+    false
+
+  #ASSERT(next(gen) == "Is")
+  #ASSERT(next(gen) == "Dog")
+
+deftest coroutine-06 :
+  defn func () :
+    try :
+      try :
+        throw(Exception("Exception A"))
+      finally :
+        throw(Exception("Exception B"))
+    catch (e) :
+      #ASSERT(to-string(e) == "Exception B")
+      throw(Exception("Exception C: %_" % [e]))
+
+  try :
+    func()
+  catch (e) :
+    #ASSERT(to-string(e) == "Exception C: Exception B")
+  
+deftest coroutine-07 :
+  var x:String = "Default X"
+
+  val gen = generate<String> :
+    let-var x = "Generator X" :
+      yield(x)
+    yield(x)
+    let-var x = "Generator X" :
+      yield(x)
+
+  #ASSERT(x == "Default X")
+  #ASSERT(next(gen) == "Generator X")
+  #ASSERT(x == "Default X")
+  #ASSERT(next(gen) == "Default X")
+  #ASSERT(x == "Default X")
+  #ASSERT(next(gen) == "Generator X")
+  #ASSERT(x == "Default X")

--- a/tests/test-coroutines.stanza
+++ b/tests/test-coroutines.stanza
@@ -557,3 +557,23 @@ deftest coroutine-09 :
     "L2: OUT"
     "L1: OUT"]
   do(step, cpu)
+
+;Does a finally block execute in the right dynamic environment?
+deftest coroutine-10 :
+
+  var X:String = "Default X"
+
+  val gen = generate<Int> :
+    let-var X = "Generator X" :
+      try :
+        yield(0)
+        yield(1)
+        yield(2)
+      finally :
+        println("Executing finally")
+        #ASSERT(X == "Generator X")
+
+  #ASSERT(next(gen) == 0)
+  #ASSERT(next(gen) == 1)
+  free(gen)
+  #ASSERT(X == "Default X")

--- a/tests/test-coroutines.stanza
+++ b/tests/test-coroutines.stanza
@@ -182,3 +182,378 @@ deftest coroutine-07 :
   #ASSERT(x == "Default X")
   #ASSERT(next(gen) == "Generator X")
   #ASSERT(x == "Default X")
+
+deftest coroutine-08 :
+
+  var STEPS:Seq<String>
+  
+  defn step (s:String) :
+    println(s)
+    #ASSERT(s == next(STEPS))
+
+  val cpu = generate<String> :
+  
+    defn main () :
+      ;Layer 1
+      dynamic-wind(
+        fn () :
+          step("L1: IN")
+        fn () :
+          ;Layer 2
+          dynamic-wind(
+            fn () :
+              step("L2: IN")
+            fn () :
+              ;Layer 3
+              step("L2: A")
+              yield("A")
+              step("L2: B")
+              yield("B")
+              step("L2: C")
+              yield("C")
+              step("L2: D")
+            fn () :
+              step("L2: OUT"))
+        fn () :
+          step("L1: OUT"))
+
+    main()
+
+  STEPS = to-seq $ [
+    "L1: IN"
+    "L2: IN"
+    "L2: A"
+    "L2: OUT"
+    "L1: OUT"
+    "A"
+    "L1: IN"
+    "L2: IN"
+    "L2: B"
+    "L2: OUT"
+    "L1: OUT"
+    "B"
+    "L1: IN"
+    "L2: IN"
+    "L2: C"
+    "L2: OUT"
+    "L1: OUT"
+    "C"
+    "L1: IN"
+    "L2: IN"
+    "L2: D"
+    "L2: OUT"
+    "L1: OUT"]
+  do(step, cpu)
+
+
+deftest coroutine-09 :
+  var STEPS:Seq<String>
+  
+  defn step (s:String) :
+    println(s)
+    #ASSERT(s == next(STEPS))
+
+  val cpu = generate<String> :
+
+    defn main () :
+
+      ;Layer 1
+      dynamic-wind(
+        fn () :
+          step("L1: IN")
+        fn () :
+          ;Layer 2
+          dynamic-wind(
+            fn () :
+              step("L2: IN")
+            fn () :          
+              ;Layer 3
+              dynamic-wind(
+                fn () :
+                  step("L3: IN")
+                  subroutine()
+                fn () :          
+                  ;Layer 4
+                  dynamic-wind(
+                    fn () :
+                      step("L4: IN")
+                    fn () :          
+                      step("L4: A")
+                      yield("> MAIN A")
+                      step("L4: B")
+                      yield("> MAIN B")
+                      step("L4: C")
+                      yield("> MAIN C")
+                      step("L4: D")
+                    fn () :
+                      step("L4: OUT"))
+                fn () :
+                  step("L3: OUT")
+                  subroutine())
+            fn () :
+              step("L2: OUT"))
+        fn () :
+          step("L1: OUT"))
+
+    defn subroutine () :
+      dynamic-wind(
+        fn () :
+          step("  SR L1: IN")
+        fn () :
+          dynamic-wind(
+            fn () :
+              step("  SR L2: IN")
+            fn () :
+              step("  SR: A")
+              yield("> SR A")
+              step("  SR: B")
+              yield("> SR B")
+              step("  SR: C")
+            fn () :
+              step("  SR L2: OUT"))          
+        fn () :
+          step("  SR L1: OUT"))
+
+    main()
+
+  STEPS = to-seq $ [
+    "L1: IN"
+    "L2: IN"
+    "L3: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L4: IN"
+    "L4: A"
+    "L4: OUT"
+    "L3: OUT"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> MAIN A"
+    "L1: IN"
+    "L2: IN"
+    "L3: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L4: IN"
+    "L4: B"
+    "L4: OUT"
+    "L3: OUT"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> MAIN B"
+    "L1: IN"
+    "L2: IN"
+    "L3: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L4: IN"
+    "L4: C"
+    "L4: OUT"
+    "L3: OUT"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> MAIN C"
+    "L1: IN"
+    "L2: IN"
+    "L3: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L4: IN"
+    "L4: D"
+    "L4: OUT"
+    "L3: OUT"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: A"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR A"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: B"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"
+    "> SR B"
+    "L1: IN"
+    "L2: IN"
+    "  SR L1: IN"
+    "  SR L2: IN"
+    "  SR: C"
+    "  SR L2: OUT"
+    "  SR L1: OUT"
+    "L2: OUT"
+    "L1: OUT"]
+  do(step, cpu)


### PR DESCRIPTION
This resolves a long-standing corner case in dynamic-wind. This occurs when `finally` blocks throws exceptions themselves which are caught in an outer-wrapped `finally` block. 

Also introduces `Throwable` and `RuntimeError` and converts hashtable operations into exceptions.